### PR TITLE
Update k8s version in examples

### DIFF
--- a/examples/vkcs_kubernetes_cluster/main.tf
+++ b/examples/vkcs_kubernetes_cluster/main.tf
@@ -1,5 +1,5 @@
 data "vkcs_kubernetes_clustertemplate" "ct" {
-  version = "1.21.4"
+  version = "1.24"
 }
 
 resource "vkcs_kubernetes_cluster" "k8s-cluster" {

--- a/examples/vkcs_kubernetes_node_group/main.tf
+++ b/examples/vkcs_kubernetes_node_group/main.tf
@@ -1,5 +1,5 @@
 data "vkcs_kubernetes_clustertemplate" "ct" {
-    version = "1.21.4"
+    version = "1.24"
 }
 
 resource "vkcs_kubernetes_cluster" "k8s-cluster" {


### PR DESCRIPTION
Set k8s version to 1.24 in examples for resource_vkcs_kubernetes_cluster and resource_vkcs_kubernetes_node_group