### PR TITLE
Add validation for vkcs_compute_instance.block_device.boot_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ description: |-
 
 #### v0.2.2 (unreleased)
 - Remove "optional" property from ip attribute of DB instance
+- Add validation and default value for block_device.boot_index of Compute instance resource
 - Fix error of concurrent file read/write in Image resource
 
 #### v0.2.1

--- a/examples/vkcs_compute_instance/main.tf
+++ b/examples/vkcs_compute_instance/main.tf
@@ -2,7 +2,6 @@ resource "vkcs_compute_instance" "compute" {
   name            = "compute-instance"
   flavor_id       = data.vkcs_compute_flavor.compute.id
   security_groups = ["default"]
-  image_id = data.vkcs_images_image.compute.id
   availability_zone = "GZ1"
 
   block_device {
@@ -20,7 +19,6 @@ resource "vkcs_compute_instance" "compute" {
     destination_type      = "volume"
     volume_type           = "ceph-ssd"
     volume_size           = 8
-    boot_index            = 1
     delete_on_termination = true
   }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/gofrs/flock v0.8.1
+	github.com/google/go-cmp v0.5.9
 	github.com/gophercloud/gophercloud v0.24.0
 	github.com/gophercloud/utils v0.0.0-20220307143606-8e7800759d16
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
@@ -21,7 +22,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect


### PR DESCRIPTION
* Set `boot_index` default value to `-1`
* Validate that user set `boot_index` to `0` if more than one `block_device` is defined
* Set `boot_index` to `0` if only one `block_device` is defined

CMPT-28985