### PR TITLE
Remove setting ip version in data_vkcs_sharedfilesystem_sharenetwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ description: |-
 - Add datasources for DB datastore capabilities and configuration parameters
 - Support cloud monitoring for DB instances/clusters
 - Add security_group argument to DB instance/cluster resources
+- Fix searching of shared network with datasource
 
 #### v0.1.16
 - Add config option to run against clouds with old cloud containers API

--- a/vkcs/data_source_vkcs_sharedfilesystem_sharenetwork.go
+++ b/vkcs/data_source_vkcs_sharedfilesystem_sharenetwork.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharenetworks"
 )
 
@@ -97,8 +96,6 @@ func dataSourceSharedFilesystemShareNetworkRead(ctx context.Context, d *schema.R
 		NeutronNetID:    d.Get("neutron_net_id").(string),
 		NeutronSubnetID: d.Get("neutron_subnet_id").(string),
 	}
-
-	listOpts.IPVersion = gophercloud.IPVersion(4)
 
 	allPages, err := sharenetworks.ListDetail(sfsClient, listOpts).AllPages()
 	if err != nil {


### PR DESCRIPTION
Shares service sets `ip_version` of share network  to `null`, which leads to not finding an object for `sharenetwork` data source due to setting `IPVersion` filter to `4`.

CMPT-31059