### PR TITLE
Fix duplicate entry error on recreating k8s cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ description: |-
 
 # VKCS Provider's changelog
 
+#### v0.2.3 (unreleased)
+- Fix duplicate entry error on recreating Kubernetes cluster
+
 #### v0.2.2
 - Remove "optional" property from ip attribute of DB instance
 - Add validation and default value for block_device.boot_index of Compute instance resource

--- a/vkcs/kubernetes/kubernetes_shared.go
+++ b/vkcs/kubernetes/kubernetes_shared.go
@@ -91,7 +91,7 @@ func kubernetesStateRefreshFunc(client *gophercloud.ServiceClient, clusterID str
 		c, err := clusters.Get(client, clusterID).Extract()
 		if err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); ok {
-				return c, string(clusterStatusDeleted), nil
+				return c, string(clusterStatusNotFound), nil
 			}
 			return nil, "", err
 		}

--- a/vkcs/kubernetes/resource_vkcs_kubernetes_cluster.go
+++ b/vkcs/kubernetes/resource_vkcs_kubernetes_cluster.go
@@ -32,6 +32,7 @@ type clusterStatus string
 var (
 	clusterStatusDeleting     clusterStatus = "DELETING"
 	clusterStatusDeleted      clusterStatus = "DELETED"
+	clusterStatusNotFound     clusterStatus = "NOT_FOUND"
 	clusterStatusReconciling  clusterStatus = "RECONCILING"
 	clusterStatusProvisioning clusterStatus = "PROVISIONING"
 	clusterStatusRunning      clusterStatus = "RUNNING"
@@ -574,8 +575,8 @@ func resourceKubernetesClusterDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{string(clusterStatusDeleting)},
-		Target:       []string{string(clusterStatusDeleted)},
+		Pending:      []string{string(clusterStatusDeleting), string(clusterStatusDeleted)},
+		Target:       []string{string(clusterStatusNotFound)},
 		Refresh:      kubernetesStateRefreshFunc(client, d.Id()),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        deleteDelay * time.Second,


### PR DESCRIPTION
This pull request fixes 409 error when updating k8s cluster by recreating due to incompletely deleted previous state version.

CMPT-31562
VKCIAC-53