### PR TITLE
Taint resources on creation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ description: |-
 
 #### v0.2.3 (unreleased)
 - Provide support for VKCS Kubernetes cluster addons
+- Mark resources as "tainted" when an error occurs during creation after a remote object has been created
 - Fix duplicate entry error on recreating Kubernetes cluster
 - Fix error when creating DB instance with specified configuration_id
 - Prevent panic when reading whether root user is enabled for DB instance

--- a/vkcs/blockstorage/resource_vkcs_blockstorage_volume.go
+++ b/vkcs/blockstorage/resource_vkcs_blockstorage_volume.go
@@ -150,10 +150,12 @@ func resourceBlockStorageVolumeCreate(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] vkcs_blockstorage_volume create options: %#v", createOpts)
 
 	v, err := volumes.Create(blockStorageClient, createOpts).Extract()
-
 	if err != nil {
 		return diag.Errorf("error creating vkcs_blockstorage_volume: %s", err)
 	}
+
+	// Store the ID now
+	d.SetId(v.ID)
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{bsVolumeStatusBuild, bsVolumeStatusDownloading},
@@ -168,9 +170,6 @@ func resourceBlockStorageVolumeCreate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.Errorf("error waiting for vkcs_blockstorage_volume %s to become ready: %s", v.ID, err)
 	}
-
-	// Store the ID now
-	d.SetId(v.ID)
 
 	return resourceBlockStorageVolumeRead(ctx, d, meta)
 }

--- a/vkcs/blockstorage/resource_vkcs_blockstorage_volume_snapshot.go
+++ b/vkcs/blockstorage/resource_vkcs_blockstorage_volume_snapshot.go
@@ -113,6 +113,9 @@ func resourceBlockStorageSnapshotCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating vkcs_blockstorage_snapshot: %s", err)
 	}
 
+	// Store the ID now
+	d.SetId(snapshot.ID)
+
 	// Wait for the volume snapshot to become available.
 	log.Printf("[DEBUG] Waiting for vkcs_blockstorage_volume_snapshot %s to become available", snapshot.ID)
 
@@ -129,9 +132,6 @@ func resourceBlockStorageSnapshotCreate(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.Errorf("error waiting for vkcs_blockstorage_volume_snapshot %s to become ready: %s", snapshot.ID, err)
 	}
-
-	// Store the ID now
-	d.SetId(snapshot.ID)
 
 	return resourceBlockStorageSnapshotRead(ctx, d, meta)
 }

--- a/vkcs/compute/resource_vkcs_compute_floatingip_associate.go
+++ b/vkcs/compute/resource_vkcs_compute_floatingip_associate.go
@@ -94,6 +94,12 @@ func resourceComputeFloatingIPAssociateCreate(ctx context.Context, d *schema.Res
 		return diag.Errorf("Error creating vkcs_compute_floatingip_associate: %s", err)
 	}
 
+	// There's an API call to get this information, but it has been
+	// deprecated. The Neutron API could be used, but I'm trying not
+	// to mix service APIs. Therefore, a faux ID will be used.
+	id := fmt.Sprintf("%s/%s/%s", floatingIP, instanceID, fixedIP)
+	d.SetId(id)
+
 	// This API call should be synchronous, but we've had reports where it isn't.
 	// If the user opted in to wait for association, then poll here.
 	var waitUntilAssociated bool
@@ -118,12 +124,6 @@ func resourceComputeFloatingIPAssociateCreate(ctx context.Context, d *schema.Res
 			return diag.FromErr(err)
 		}
 	}
-
-	// There's an API call to get this information, but it has been
-	// deprecated. The Neutron API could be used, but I'm trying not
-	// to mix service APIs. Therefore, a faux ID will be used.
-	id := fmt.Sprintf("%s/%s/%s", floatingIP, instanceID, fixedIP)
-	d.SetId(id)
 
 	return resourceComputeFloatingIPAssociateRead(ctx, d, meta)
 }

--- a/vkcs/compute/resource_vkcs_compute_interface_attach.go
+++ b/vkcs/compute/resource_vkcs_compute_interface_attach.go
@@ -118,6 +118,10 @@ func resourceComputeInterfaceAttachCreate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
+	// Use the instance ID and attachment ID as the resource ID.
+	id := fmt.Sprintf("%s/%s", instanceID, attachment.PortID)
+	d.SetId(id)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"ATTACHING"},
 		Target:     []string{"ATTACHED"},
@@ -131,12 +135,7 @@ func resourceComputeInterfaceAttachCreate(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("Error creating vkcs_compute_interface_attach %s: %s", instanceID, err)
 	}
 
-	// Use the instance ID and attachment ID as the resource ID.
-	id := fmt.Sprintf("%s/%s", instanceID, attachment.PortID)
-
 	log.Printf("[DEBUG] Created vkcs_compute_interface_attach %s: %#v", id, attachment)
-
-	d.SetId(id)
 
 	return resourceComputeInterfaceAttachRead(ctx, d, meta)
 }

--- a/vkcs/compute/resource_vkcs_compute_volume_attach.go
+++ b/vkcs/compute/resource_vkcs_compute_volume_attach.go
@@ -101,6 +101,12 @@ func resourceComputeVolumeAttachCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("Error creating vkcs_compute_volume_attach %s: %s", instanceID, err)
 	}
 
+	// Use the instance ID and attachment ID as the resource ID.
+	// This is because an attachment cannot be retrieved just by its ID alone.
+	id := fmt.Sprintf("%s/%s", instanceID, attachment.ID)
+
+	d.SetId(id)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"ATTACHING"},
 		Target:     []string{"ATTACHED"},
@@ -113,12 +119,6 @@ func resourceComputeVolumeAttachCreate(ctx context.Context, d *schema.ResourceDa
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
 		return diag.Errorf("Error attaching vkcs_compute_volume_attach %s: %s", instanceID, err)
 	}
-
-	// Use the instance ID and attachment ID as the resource ID.
-	// This is because an attachment cannot be retrieved just by its ID alone.
-	id := fmt.Sprintf("%s/%s", instanceID, attachment.ID)
-
-	d.SetId(id)
 
 	return resourceComputeVolumeAttachRead(ctx, d, meta)
 }

--- a/vkcs/db/resource_vkcs_db_backup.go
+++ b/vkcs/db/resource_vkcs_db_backup.go
@@ -196,6 +196,9 @@ func resourceDatabaseBackupCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating vkcs_db_backup: %s", err)
 	}
 
+	// Store the ID now
+	d.SetId(backup.ID)
+
 	// Wait for the backup to become available.
 	log.Printf("[DEBUG] Waiting for vkcs_db_backup %s to become available", backup.ID)
 
@@ -212,9 +215,6 @@ func resourceDatabaseBackupCreate(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.Errorf("error waiting for vkcs_db_backup %s to become ready: %s", backup.ID, err)
 	}
-
-	// Store the ID now
-	d.SetId(backup.ID)
 
 	return resourceDatabaseBackupRead(ctx, d, meta)
 }

--- a/vkcs/db/resource_vkcs_db_cluster.go
+++ b/vkcs/db/resource_vkcs_db_cluster.go
@@ -563,6 +563,9 @@ func resourceDatabaseClusterCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating vkcs_db_cluster: %s", err)
 	}
 
+	// Store the ID now
+	d.SetId(cluster.ID)
+
 	// Wait for the cluster to become available.
 	log.Printf("[DEBUG] Waiting for vkcs_db_cluster %s to become available", cluster.ID)
 
@@ -591,8 +594,6 @@ func resourceDatabaseClusterCreate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	// Store the ID now
-	d.SetId(cluster.ID)
 	return resourceDatabaseClusterRead(ctx, d, meta)
 }
 

--- a/vkcs/db/resource_vkcs_db_cluster_with_shards.go
+++ b/vkcs/db/resource_vkcs_db_cluster_with_shards.go
@@ -528,6 +528,9 @@ func resourceDatabaseClusterWithShardsCreate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("error creating vkcs_db_cluster_with_shards: %s", err)
 	}
 
+	// Store the ID now
+	d.SetId(cluster.ID)
+
 	// Wait for the cluster to become available.
 	log.Printf("[DEBUG] Waiting for vkcs_db_cluster_with_shards %s to become available", cluster.ID)
 
@@ -556,8 +559,6 @@ func resourceDatabaseClusterWithShardsCreate(ctx context.Context, d *schema.Reso
 		}
 	}
 
-	// Store the ID now
-	d.SetId(cluster.ID)
 	return resourceDatabaseClusterWithShardsRead(ctx, d, meta)
 }
 

--- a/vkcs/db/resource_vkcs_db_database.go
+++ b/vkcs/db/resource_vkcs_db_database.go
@@ -113,6 +113,11 @@ func resourceDatabaseDatabaseCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error creating vkcs_db_database: %s", err)
 	}
 
+	// Store the ID now
+	d.SetId(fmt.Sprintf("%s/%s", dbmsID, databaseName))
+	// Store dbms type
+	d.Set("dbms_type", dbmsType)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"BUILD"},
 		Target:     []string{"ACTIVE"},
@@ -126,11 +131,6 @@ func resourceDatabaseDatabaseCreate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.Errorf("error waiting for vkcs_db_database %s to be created: %s", databaseName, err)
 	}
-
-	// Store the ID now
-	d.SetId(fmt.Sprintf("%s/%s", dbmsID, databaseName))
-	// Store dbms type
-	d.Set("dbms_type", dbmsType)
 
 	return resourceDatabaseDatabaseRead(ctx, d, meta)
 }

--- a/vkcs/db/resource_vkcs_db_instance.go
+++ b/vkcs/db/resource_vkcs_db_instance.go
@@ -599,6 +599,9 @@ func resourceDatabaseInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error creating vkcs_db_instance: %s", err)
 	}
 
+	// Store the ID now
+	d.SetId(instance.ID)
+
 	// Wait for the instance to become available.
 	log.Printf("[DEBUG] Waiting for vkcs_db_instance %s to become available", instance.ID)
 
@@ -641,9 +644,6 @@ func resourceDatabaseInstanceCreate(ctx context.Context, d *schema.ResourceData,
 			d.Set("root_password", rootUser.Password)
 		}
 	}
-
-	// Store the ID now
-	d.SetId(instance.ID)
 
 	return resourceDatabaseInstanceRead(ctx, d, meta)
 }

--- a/vkcs/db/resource_vkcs_db_user.go
+++ b/vkcs/db/resource_vkcs_db_user.go
@@ -132,6 +132,11 @@ func resourceDatabaseUserCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error creating vkcs_db_user: %s", err)
 	}
 
+	// Store the ID now
+	d.SetId(fmt.Sprintf("%s/%s", dbmsID, userName))
+	// Store dbms type
+	d.Set("dbms_type", dbmsType)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"BUILD"},
 		Target:     []string{"ACTIVE"},
@@ -145,11 +150,6 @@ func resourceDatabaseUserCreate(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return diag.Errorf("error waiting for vkcs_db_user %s to be created: %s", userName, err)
 	}
-
-	// Store the ID now
-	d.SetId(fmt.Sprintf("%s/%s", dbmsID, userName))
-	// Store dbms type
-	d.Set("dbms_type", dbmsType)
 
 	return resourceDatabaseUserRead(ctx, d, meta)
 }

--- a/vkcs/firewall/resource_vkcs_networking_secgroup.go
+++ b/vkcs/firewall/resource_vkcs_networking_secgroup.go
@@ -105,6 +105,8 @@ func resourceNetworkingSecGroupCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("Error creating vkcs_networking_secgroup: %s", err)
 	}
 
+	d.SetId(sg.ID)
+
 	// Delete the default security group rules if it has been requested.
 	deleteDefaultRules := d.Get("delete_default_rules").(bool)
 	if deleteDefaultRules {
@@ -120,8 +122,6 @@ func resourceNetworkingSecGroupCreate(ctx context.Context, d *schema.ResourceDat
 			}
 		}
 	}
-
-	d.SetId(sg.ID)
 
 	tags := networking.NetworkingAttributesTags(d)
 	if len(tags) > 0 {

--- a/vkcs/keymanager/resource_vkcs_keymanager_container.go
+++ b/vkcs/keymanager/resource_vkcs_keymanager_container.go
@@ -177,6 +177,7 @@ func resourceKeyManagerContainerCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	uuid := keyManagerContainerGetUUIDfromContainerRef(container.ContainerRef)
+	d.SetId(uuid)
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"PENDING"},
@@ -191,8 +192,6 @@ func resourceKeyManagerContainerCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_keymanager_container: %s", err)
 	}
-
-	d.SetId(uuid)
 
 	d.Partial(true)
 

--- a/vkcs/keymanager/resource_vkcs_keymanager_secret.go
+++ b/vkcs/keymanager/resource_vkcs_keymanager_secret.go
@@ -239,6 +239,7 @@ func resourceKeyManagerSecretCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	uuid := KeyManagerSecretGetUUIDfromSecretRef(secret.SecretRef)
+	d.SetId(uuid)
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"PENDING"},
@@ -253,8 +254,6 @@ func resourceKeyManagerSecretCreate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_keymanager_secret: %s", err)
 	}
-
-	d.SetId(uuid)
 
 	d.Partial(true)
 

--- a/vkcs/lb/resource_vkcs_lb_l7policy.go
+++ b/vkcs/lb/resource_vkcs_lb_l7policy.go
@@ -189,13 +189,13 @@ func resourceL7PolicyCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("Error creating L7 Policy: %s", err)
 	}
 
+	d.SetId(l7Policy.ID)
+
 	// Wait for L7 Policy to become active before continuing
 	err = waitForLBL7Policy(ctx, lbClient, parentListener, l7Policy, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(l7Policy.ID)
 
 	return resourceL7PolicyRead(ctx, d, meta)
 }

--- a/vkcs/lb/resource_vkcs_lb_l7rule.go
+++ b/vkcs/lb/resource_vkcs_lb_l7rule.go
@@ -186,14 +186,14 @@ func resourceL7RuleCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("Error creating L7 Rule: %s", err)
 	}
 
+	d.SetId(l7Rule.ID)
+	d.Set("listener_id", listenerID)
+
 	// Wait for L7 Rule to become active before continuing
 	err = waitForLBL7Rule(ctx, lbClient, parentListener, parentL7Policy, l7Rule, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(l7Rule.ID)
-	d.Set("listener_id", listenerID)
 
 	return resourceL7RuleRead(ctx, d, meta)
 }

--- a/vkcs/lb/resource_vkcs_lb_listener.go
+++ b/vkcs/lb/resource_vkcs_lb_listener.go
@@ -252,13 +252,13 @@ func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("Error creating vkcs_lb_listener: %s", err)
 	}
 
+	d.SetId(listener.ID)
+
 	// Wait for the listener to become ACTIVE.
 	err = waitForLBListener(ctx, lbClient, listener, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(listener.ID)
 
 	return resourceListenerRead(ctx, d, meta)
 }

--- a/vkcs/lb/resource_vkcs_lb_loadbalancer.go
+++ b/vkcs/lb/resource_vkcs_lb_loadbalancer.go
@@ -159,14 +159,14 @@ func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 	lbID = lb.ID
 
+	d.SetId(lbID)
+
 	// Wait for load-balancer to become active before continuing.
 	timeout := d.Timeout(schema.TimeoutCreate)
 	err = waitForLBLoadBalancer(ctx, lbClient, lbID, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(lbID)
 
 	return resourceLoadBalancerRead(ctx, d, meta)
 }

--- a/vkcs/lb/resource_vkcs_lb_member.go
+++ b/vkcs/lb/resource_vkcs_lb_member.go
@@ -153,13 +153,13 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("Error creating member: %s", err)
 	}
 
+	d.SetId(member.ID)
+
 	// Wait for member to become active before continuing
 	err = waitForLBMember(ctx, lbClient, parentPool, member, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(member.ID)
 
 	return resourceMemberRead(ctx, d, meta)
 }

--- a/vkcs/lb/resource_vkcs_lb_members.go
+++ b/vkcs/lb/resource_vkcs_lb_members.go
@@ -149,13 +149,13 @@ func resourceMembersCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("Error creating members: %s", err)
 	}
 
+	d.SetId(poolID)
+
 	// Wait for parent pool to become active before continuing
 	err = waitForLBPool(ctx, lbClient, parentPool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(poolID)
 
 	return resourceMembersRead(ctx, d, meta)
 }

--- a/vkcs/lb/resource_vkcs_lb_monitor.go
+++ b/vkcs/lb/resource_vkcs_lb_monitor.go
@@ -174,13 +174,13 @@ func resourceMonitorCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("Unable to create vkcs_lb_monitor: %s", err)
 	}
 
+	d.SetId(monitor.ID)
+
 	// Wait for monitor to become active before continuing
 	err = waitForLBMonitor(ctx, lbClient, parentPool, monitor, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(monitor.ID)
 
 	return resourceMonitorRead(ctx, d, meta)
 }

--- a/vkcs/lb/resource_vkcs_lb_pool.go
+++ b/vkcs/lb/resource_vkcs_lb_pool.go
@@ -212,14 +212,14 @@ func resourcePoolCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("Error creating pool: %s", err)
 	}
 
+	d.SetId(pool.ID)
+
 	// Pool was successfully created
 	// Wait for pool to become active before continuing
 	err = waitForLBPool(ctx, lbClient, pool, "ACTIVE", getLbPendingStatuses(), timeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(pool.ID)
 
 	return resourcePoolRead(ctx, d, meta)
 }

--- a/vkcs/networking/resource_vkcs_networking_floatingip.go
+++ b/vkcs/networking/resource_vkcs_networking_floatingip.go
@@ -183,6 +183,8 @@ func resourceNetworkFloatingIPCreate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
+	d.SetId(fip.ID)
+
 	log.Printf("[DEBUG] Waiting for vkcs_networking_floatingip %s to become available.", fip.ID)
 
 	stateConf := &retry.StateChangeConf{
@@ -197,8 +199,6 @@ func resourceNetworkFloatingIPCreate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_networking_floatingip %s to become available: %s", fip.ID, err)
 	}
-
-	d.SetId(fip.ID)
 
 	if createOpts.SubnetID != "" {
 		// resourceNetworkFloatingIPRead doesn't handle this, since FIP GET request doesn't provide this info.

--- a/vkcs/networking/resource_vkcs_networking_network.go
+++ b/vkcs/networking/resource_vkcs_networking_network.go
@@ -154,6 +154,8 @@ func resourceNetworkingNetworkCreate(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("Error creating vkcs_networking_network: %s", err)
 	}
 
+	d.SetId(n.ID)
+
 	log.Printf("[DEBUG] Waiting for vkcs_networking_network %s to become available.", n.ID)
 
 	stateConf := &retry.StateChangeConf{
@@ -169,8 +171,6 @@ func resourceNetworkingNetworkCreate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_networking_network %s to become available: %s", n.ID, err)
 	}
-
-	d.SetId(n.ID)
 
 	tags := NetworkingAttributesTags(d)
 	if len(tags) > 0 {

--- a/vkcs/networking/resource_vkcs_networking_port.go
+++ b/vkcs/networking/resource_vkcs_networking_port.go
@@ -334,6 +334,8 @@ func resourceNetworkingPortCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("Error creating vkcs_networking_port: %s", err)
 	}
 
+	d.SetId(port.ID)
+
 	log.Printf("[DEBUG] Waiting for vkcs_networking_port %s to become available.", port.ID)
 
 	stateConf := &retry.StateChangeConf{
@@ -348,8 +350,6 @@ func resourceNetworkingPortCreate(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_networking_port %s to become available: %s", port.ID, err)
 	}
-
-	d.SetId(port.ID)
 
 	tags := NetworkingAttributesTags(d)
 	if len(tags) > 0 {

--- a/vkcs/networking/resource_vkcs_networking_router.go
+++ b/vkcs/networking/resource_vkcs_networking_router.go
@@ -176,6 +176,8 @@ func resourceNetworkingRouterCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("Error creating vkcs_networking_router: %s", err)
 	}
 
+	d.SetId(r.ID)
+
 	log.Printf("[DEBUG] Waiting for vkcs_networking_router %s to become available.", r.ID)
 
 	stateConf := &retry.StateChangeConf{
@@ -191,8 +193,6 @@ func resourceNetworkingRouterCreate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_networking_router %s to become available: %s", r.ID, err)
 	}
-
-	d.SetId(r.ID)
 
 	// If the vendorUpdateGateway flag was specified and if an external network
 	// was specified, then set the gateway information after router creation.

--- a/vkcs/networking/resource_vkcs_networking_router_interface.go
+++ b/vkcs/networking/resource_vkcs_networking_router_interface.go
@@ -93,6 +93,8 @@ func resourceNetworkingRouterInterfaceCreate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("Error creating vkcs_networking_router_interface: %s", err)
 	}
 
+	d.SetId(r.PortID)
+
 	log.Printf("[DEBUG] Waiting for vkcs_networking_router_interface %s to become available", r.PortID)
 
 	stateConf := &retry.StateChangeConf{
@@ -108,8 +110,6 @@ func resourceNetworkingRouterInterfaceCreate(ctx context.Context, d *schema.Reso
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_networking_router_interface %s to become available: %s", r.ID, err)
 	}
-
-	d.SetId(r.PortID)
 
 	log.Printf("[DEBUG] Created vkcs_networking_router_interface %s: %#v", r.ID, r)
 	return resourceNetworkingRouterInterfaceRead(ctx, d, meta)

--- a/vkcs/networking/resource_vkcs_networking_subnet.go
+++ b/vkcs/networking/resource_vkcs_networking_subnet.go
@@ -250,6 +250,8 @@ func resourceNetworkingSubnetCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("Error creating vkcs_networking_subnet: %s", err)
 	}
 
+	d.SetId(s.ID)
+
 	log.Printf("[DEBUG] Waiting for vkcs_networking_subnet %s to become available", s.ID)
 	stateConf := &retry.StateChangeConf{
 		Target:     []string{"ACTIVE"},
@@ -263,8 +265,6 @@ func resourceNetworkingSubnetCreate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_networking_subnet %s to become available: %s", s.ID, err)
 	}
-
-	d.SetId(s.ID)
 
 	tags := NetworkingAttributesTags(d)
 	if len(tags) > 0 {

--- a/vkcs/sharedfilesystem/resource_vkcs_sharedfilesystem_share_access.go
+++ b/vkcs/sharedfilesystem/resource_vkcs_sharedfilesystem_share_access.go
@@ -127,6 +127,8 @@ func resourceSharedFilesystemShareAccessCreate(ctx context.Context, d *schema.Re
 		}
 	}
 
+	d.SetId(access.ID)
+
 	log.Printf("[DEBUG] Waiting for vkcs_sharedfilesystem_share_access %s to become available.", access.ID)
 	stateConf := &retry.StateChangeConf{
 		Target:     []string{"active"},
@@ -141,8 +143,6 @@ func resourceSharedFilesystemShareAccessCreate(ctx context.Context, d *schema.Re
 	if err != nil {
 		return diag.Errorf("Error waiting for vkcs_sharedfilesystem_share_access %s to become available: %s", access.ID, err)
 	}
-
-	d.SetId(access.ID)
 
 	return resourceSharedFilesystemShareAccessRead(ctx, d, meta)
 }

--- a/vkcs/vpnaas/resource_vkcs_vpnaas_endpoint_group.go
+++ b/vkcs/vpnaas/resource_vkcs_vpnaas_endpoint_group.go
@@ -99,6 +99,8 @@ func resourceEndpointGroupCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	d.SetId(group.ID)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
@@ -114,8 +116,6 @@ func resourceEndpointGroupCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	log.Printf("[DEBUG] EndpointGroup created: %#v", group)
-
-	d.SetId(group.ID)
 
 	return resourceEndpointGroupRead(ctx, d, meta)
 }

--- a/vkcs/vpnaas/resource_vkcs_vpnaas_ike_policy.go
+++ b/vkcs/vpnaas/resource_vkcs_vpnaas_ike_policy.go
@@ -138,6 +138,8 @@ func resourceIKEPolicyCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
+	d.SetId(policy.ID)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
@@ -153,8 +155,6 @@ func resourceIKEPolicyCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[DEBUG] IKE policy created: %#v", policy)
-
-	d.SetId(policy.ID)
 
 	return resourceIKEPolicyRead(ctx, d, meta)
 }

--- a/vkcs/vpnaas/resource_vkcs_vpnaas_ipsec_policy.go
+++ b/vkcs/vpnaas/resource_vkcs_vpnaas_ipsec_policy.go
@@ -139,6 +139,8 @@ func resourceIPSecPolicyCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
+	d.SetId(policy.ID)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
 		Target:     []string{"ACTIVE"},
@@ -154,8 +156,6 @@ func resourceIPSecPolicyCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("[DEBUG] IPSec policy created: %#v", policy)
-
-	d.SetId(policy.ID)
 
 	return resourceIPSecPolicyRead(ctx, d, meta)
 }

--- a/vkcs/vpnaas/resource_vkcs_vpnaas_service.go
+++ b/vkcs/vpnaas/resource_vkcs_vpnaas_service.go
@@ -117,6 +117,8 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
+	d.SetId(service.ID)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"NOT_CREATED"},
 		Target:     []string{"PENDING_CREATE"},
@@ -132,8 +134,6 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Service created: %#v", service)
-
-	d.SetId(service.ID)
 
 	return resourceServiceRead(ctx, d, meta)
 }

--- a/vkcs/vpnaas/resource_vkcs_vpnaas_site_connection.go
+++ b/vkcs/vpnaas/resource_vkcs_vpnaas_site_connection.go
@@ -204,6 +204,8 @@ func resourceSiteConnectionCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	d.SetId(conn.ID)
+
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"NOT_CREATED"},
 		Target:     []string{"PENDING_CREATE"},
@@ -219,8 +221,6 @@ func resourceSiteConnectionCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[DEBUG] SiteConnection created: %#v", conn)
-
-	d.SetId(conn.ID)
 
 	return resourceSiteConnectionRead(ctx, d, meta)
 }


### PR DESCRIPTION
Mark resources as tainted when an error occures during resource creation after a remote object has been created

CMPT-31584