### PR TITLE
Update configuration group logic for DB clusters and instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ description: |-
 
 # VKCS Provider's changelog
 
-### v0.3.1
+#### v0.3.1 (unreleased)
 - Add vkcs_backup_providers datasource
 - Add vkcs_backup_provider datasource
 - Add vkcs_backup_plan resource and datasource
+- Fix error of unexpected "restart_required" status for DB instance
 
 #### v0.3.0
 - Provide support for Kubernetes cluster addons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ description: |-
 - Add vkcs_backup_providers datasource
 - Add vkcs_backup_provider datasource
 - Add vkcs_backup_plan resource and datasource
+- Add restart_confirmed vendor option to DB clusters and instance
 - Fix creating/updating DB clusters with specified configuration_id
 - Fix error of unexpected "restart_required" status for DB instance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ description: |-
 - Add vkcs_backup_providers datasource
 - Add vkcs_backup_provider datasource
 - Add vkcs_backup_plan resource and datasource
+- Fix creating/updating DB clusters with specified configuration_id
 - Fix error of unexpected "restart_required" status for DB instance
 
 #### v0.3.0

--- a/vkcs/db/db_cluster.go
+++ b/vkcs/db/db_cluster.go
@@ -248,6 +248,9 @@ func databaseClusterActionUpdateConfigurationBase(updateCtx *dbResourceUpdateCon
 		return fmt.Errorf("%w: %s", errDBClusterActionUpdateConfiguration, err)
 	}
 
+	updateCtx.StateConf.Pending = []string{string(dbClusterStatusUpdating)}
+	updateCtx.StateConf.Target = []string{string(dbClusterStatusActive)}
+
 	log.Printf("[DEBUG] Detaching configuration %s from cluster %s", detachOpts.ConfigurationDetach.ConfigurationID, clusterID)
 	err = updateCtx.WaitForStateContext()
 	if err != nil {

--- a/vkcs/db/resource_vkcs_db_cluster_test.go
+++ b/vkcs/db/resource_vkcs_db_cluster_test.go
@@ -254,6 +254,10 @@ resource "vkcs_db_cluster" "basic" {
 
   availability_zone = "{{.AvailabilityZone}}"
 
+  vendor_options {
+	restart_confirmed = true
+  }
+
   depends_on = [vkcs_networking_router_interface.base]
 }
 `

--- a/vkcs/db/resource_vkcs_db_cluster_test.go
+++ b/vkcs/db/resource_vkcs_db_cluster_test.go
@@ -186,58 +186,80 @@ const testAccDatabaseClusterBasic = `
 {{.BaseNetwork}}
 {{.BaseFlavor}}
 
- resource "vkcs_db_cluster" "basic" {
-   name      = "basic"
-   flavor_id = data.vkcs_compute_flavor.base.id
-   volume_size      = 8
-   volume_type = "{{.VolumeType}}"
-   cluster_size = 3
-   datastore {
-	version = "13"
-	type    = "postgresql"
+resource "vkcs_db_config_group" "basic" {
+  name = "basic"
+  datastore {
+    version = "13"
+    type    = "postgresql"
+  }
+  values = {
+    max_connections : "100"
+  }
+}
+
+resource "vkcs_db_cluster" "basic" {
+  name         = "basic"
+  flavor_id    = data.vkcs_compute_flavor.base.id
+  volume_size  = 8
+  volume_type  = "{{.VolumeType}}"
+  cluster_size = 3
+  datastore {
+    version = "13"
+    type    = "postgresql"
+  }
+  configuration_id = vkcs_db_config_group.basic.id
+  network {
+    uuid = vkcs_networking_network.base.id
   }
 
-   network {
-     uuid = vkcs_networking_network.base.id
-   }
-	
-   availability_zone = "{{.AvailabilityZone}}"
+  availability_zone = "{{.AvailabilityZone}}"
 
-   depends_on = [
+  depends_on = [
     vkcs_networking_router_interface.base
   ]
- }
+}
 `
 
 const testAccDatabaseClusterUpdate = `
 {{.BaseNetwork}}
 {{.BaseNewFlavor}}
 
-resource "vkcs_db_cluster" "basic" {
-	name      = "basic"
-	flavor_id = data.vkcs_compute_flavor.base.id
-	cloud_monitoring_enabled = true
-	volume_size      = 9
-	volume_type = "{{.VolumeType}}"
-	cluster_size = 3
-	datastore {
-	 version = "13"
-	 type    = "postgresql"
-   }
- 
-	network {
-	  uuid = vkcs_networking_network.base.id
-	}
-	 
-	availability_zone = "{{.AvailabilityZone}}"
-
-	depends_on = [vkcs_networking_router_interface.base]
+resource "vkcs_db_config_group" "basic" {
+  name = "basic"
+  datastore {
+    version = "13"
+    type    = "postgresql"
   }
+  values = {
+    max_connections : "200"
+  }
+}
+
+resource "vkcs_db_cluster" "basic" {
+  name                     = "basic"
+  flavor_id                = data.vkcs_compute_flavor.base.id
+  cloud_monitoring_enabled = true
+  volume_size              = 9
+  volume_type              = "{{.VolumeType}}"
+  cluster_size             = 3
+  datastore {
+    version = "13"
+    type    = "postgresql"
+  }
+  configuration_id = vkcs_db_config_group.basic.id
+
+  network {
+    uuid = vkcs_networking_network.base.id
+  }
+
+  availability_zone = "{{.AvailabilityZone}}"
+
+  depends_on = [vkcs_networking_router_interface.base]
+}
 `
 
 const testAccDatabaseClusterWal = `
-{{.BaseNetwork}}
-				
+{{.BaseNetwork}}	
 {{.BaseFlavor}}
 
  resource "vkcs_db_cluster" "basic" {
@@ -271,8 +293,7 @@ const testAccDatabaseClusterWal = `
 `
 
 const testAccDatabaseClusterShrinkInitial = `
-{{.BaseNetwork}}
-				
+{{.BaseNetwork}}	
 {{.BaseFlavor}}
 
  resource "vkcs_db_cluster" "basic" {
@@ -295,8 +316,7 @@ const testAccDatabaseClusterShrinkInitial = `
 `
 
 var testAccDatabaseClusterShrinkUpdated = `
-{{.BaseNetwork}}
-				
+{{.BaseNetwork}}	
 {{.BaseFlavor}}
 
  resource "vkcs_db_cluster" "basic" {

--- a/vkcs/db/resource_vkcs_db_cluster_with_shards_test.go
+++ b/vkcs/db/resource_vkcs_db_cluster_with_shards_test.go
@@ -280,6 +280,10 @@ resource "vkcs_db_cluster_with_shards" "update" {
     availability_zone = "{{.AvailabilityZone}}"
   }
 
+  vendor_options {
+	restart_confirmed = true
+  }
+
   depends_on = [vkcs_networking_router_interface.base]
 }
 `

--- a/vkcs/db/resource_vkcs_db_config_group_test.go
+++ b/vkcs/db/resource_vkcs_db_config_group_test.go
@@ -188,6 +188,11 @@ resource "vkcs_db_instance" "basic" {
     autoexpand = true
     max_disk_size = 1000
   }
+
+  vendor_options {
+	restart_confirmed = true
+  }
+  
   depends_on = [vkcs_networking_router_interface.base]
 }
 `

--- a/vkcs/internal/services/db/v1/clusters/requests.go
+++ b/vkcs/internal/services/db/v1/clusters/requests.go
@@ -49,14 +49,16 @@ type InstanceCreateOpts struct {
 // AttachConfigurationGroupOpts represents parameters of configuration group to be attached to database cluster
 type AttachConfigurationGroupOpts struct {
 	ConfigurationAttach struct {
-		ConfigurationID string `json:"configuration_id"`
+		ConfigurationID  string `json:"configuration_id"`
+		RestartConfirmed *bool  `json:"restart_confirmed"`
 	} `json:"configuration_attach"`
 }
 
 // DetachConfigurationGroupOpts represents parameters of configuration group to be detached from database cluster
 type DetachConfigurationGroupOpts struct {
 	ConfigurationDetach struct {
-		ConfigurationID string `json:"configuration_id"`
+		ConfigurationID  string `json:"configuration_id"`
+		RestartConfirmed *bool  `json:"restart_confirmed"`
 	} `json:"configuration_detach"`
 }
 

--- a/vkcs/internal/services/db/v1/instances/requests.go
+++ b/vkcs/internal/services/db/v1/instances/requests.go
@@ -66,14 +66,18 @@ type DetachReplicaOpts struct {
 
 // AttachConfigurationGroupOpts represents parameters of configuration group to be attached to database instance
 type AttachConfigurationGroupOpts struct {
-	Instance struct {
+	RestartConfirmed *bool `json:"restart_confirmed"`
+	Instance         struct {
 		Configuration string `json:"configuration"`
 	} `json:"instance"`
 }
 
 // DetachConfigurationGroupOpts represents parameters of configuration group to be detached from database instance
 type DetachConfigurationGroupOpts struct {
-	Instance map[string]interface{} `json:"instance"`
+	RestartConfirmed *bool `json:"restart_confirmed"`
+	Instance         struct {
+		Configuration string `json:"configuration"`
+	} `json:"instance"`
 }
 
 // UpdateAutoExpandOpts represents parameters of request to update autoresize properties of volume of database instance
@@ -324,10 +328,7 @@ func UpdateAutoExpand(client *gophercloud.ServiceClient, id string, opts OptsBui
 }
 
 // DetachConfigurationGroup performs request to detach configuration group from database instance
-func DetachConfigurationGroup(client *gophercloud.ServiceClient, id string) (r ConfigurationResult) {
-	opts := DetachConfigurationGroupOpts{
-		Instance: map[string]interface{}{},
-	}
+func DetachConfigurationGroup(client *gophercloud.ServiceClient, id string, opts OptsBuilder) (r ConfigurationResult) {
 	b, err := opts.Map()
 	if err != nil {
 		r.Err = err


### PR DESCRIPTION
- Add handling of RESTART_REQUIRED status for DB instance
- Fix clusters creation with specified `configuration_id`
- Add `restart_confirmed` vendor option to control auto-restart when it is needed to apply configuration group changes

CMPT-31686