### PR TITLE
Fix error of unexpected Kubernetes cluster status after creating/deleting an addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ description: |-
 #### v0.5.0 (unreleased)
 - Add Direct Connect resources and data sources
 - Fix Kubernetes addon state refresh panic on error
+- Fix error of unexpected Kubernetes cluster status after creating/deleting an addon
 
 #### v0.4.2
 - Add data source for images


### PR DESCRIPTION
After creation/deletion an addon, cluster may have a RECONCILING status, leading to possible unexpected status errors when another operation is applied to the cluster after the specified addon operations.

CMPT-32382