### PR TITLE
fix examples and acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ description: |-
 - Add vkcs_networking_sdn data source for getting a list of available SDNs.
 - Add traffic_selector_ep_merge argument to vkcs_vpnaas_site_connection resource.
 - Add external_fixed_ips computed field to vkcs_networking_router resource and data source.
+- Update the Compute API client micro version to 2.42
 - Fix searching for a subnet with a filter by "tags" in the vkcs_networking_subnet data source
+- Fix unnecessary resource recreation due to shelve/unshelve operations on vkcs_compute_instance
 
 #### v0.7.3
 - Add security_group_ids argument to vkcs_compute_instance resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ description: |-
 - Add vkcs_networking_sdn data source for getting a list of available SDNs.
 - Add traffic_selector_ep_merge argument to vkcs_vpnaas_site_connection resource.
 - Add external_fixed_ips computed field to vkcs_networking_router resource and data source.
+- Fix searching for a subnet with a filter by "tags" in the vkcs_networking_subnet data source
 
 #### v0.7.3
 - Add security_group_ids argument to vkcs_compute_instance resource

--- a/examples/kubernetes/addon/data-addon.tf
+++ b/examples/kubernetes/addon/data-addon.tf
@@ -1,5 +1,5 @@
 data "vkcs_kubernetes_addon" "kube-prometheus-stack" {
   cluster_id = vkcs_kubernetes_cluster.k8s-cluster.id
   name       = "kube-prometheus-stack"
-  version    = "36.2.0"
+  version    = "54.2.2"
 }

--- a/examples/kubernetes/clustertemplate/main.tf
+++ b/examples/kubernetes/clustertemplate/main.tf
@@ -1,3 +1,3 @@
 data "vkcs_kubernetes_clustertemplate" "k8s_24" {
-  version = "1.24"
+  version = "1.27"
 }

--- a/vkcs/backup/data_source_providers_test.go
+++ b/vkcs/backup/data_source_providers_test.go
@@ -15,7 +15,7 @@ func TestAccBackupProvidersDataSource_basic(t *testing.T) {
 				ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
 				Config:                   testAccBackupProvidersDataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.vkcs_backup_providers.providers", "providers.#", "2"),
+					resource.TestCheckResourceAttr("data.vkcs_backup_providers.providers", "providers.#", "3"),
 				),
 			},
 		},

--- a/vkcs/compute/data_source_instance.go
+++ b/vkcs/compute/data_source_instance.go
@@ -251,7 +251,6 @@ func dataSourceComputeInstanceRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	// Populate tags.
-	computeClient.Microversion = computeAPIMicroVersion
 	instanceTags, err := itags.List(computeClient, server.ID).Extract()
 	if err != nil {
 		log.Printf("[DEBUG] Unable to get tags for vkcs_compute_instance: %s", err)

--- a/vkcs/compute/instance.go
+++ b/vkcs/compute/instance.go
@@ -25,10 +25,6 @@ import (
 	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util"
 )
 
-const (
-	computeAPIMicroVersion = "2.42"
-)
-
 // InstanceNIC is a structured representation of a Gophercloud servers.Server
 // virtual NIC.
 type InstanceNIC struct {

--- a/vkcs/internal/acctest/acctest.go
+++ b/vkcs/internal/acctest/acctest.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -194,4 +195,17 @@ func ImportStep(resourceName string) resource.TestStep {
 		ImportState:       true,
 		ImportStateVerify: true,
 	}
+}
+
+func GenerateUniqueTestFields(testName string) map[string]string {
+	t := time.Now()
+	return map[string]string{
+		"TestName":    testName,
+		"CurrentTime": fmt.Sprintf("%dd-%dh-%dm", t.Day(), t.Hour(), t.Minute()),
+	}
+}
+
+func GenerateNameSuffix() string {
+	t := time.Now()
+	return fmt.Sprintf("%dd-%dh-%dm", t.Day(), t.Hour(), t.Minute())
 }

--- a/vkcs/internal/clients/config.go
+++ b/vkcs/internal/clients/config.go
@@ -24,6 +24,7 @@ const (
 	maxRetriesCount         = 3
 	requestsMaxRetriesCount = 3
 	requestsRetryDelay      = 1 * time.Second
+	computeAPIMicroVersion  = "2.42"
 )
 
 // Config is interface to work with configer calls
@@ -119,7 +120,14 @@ func (c *configer) GetTenantID() string {
 }
 
 func (c *configer) ComputeV2Client(region string) (*gophercloud.ServiceClient, error) {
-	return c.Config.ComputeV2Client(region)
+	computeClient, err := c.Config.ComputeV2Client(region)
+	if err != nil {
+		return nil, err
+	}
+
+	computeClient.Microversion = computeAPIMicroVersion
+
+	return computeClient, nil
 }
 
 func (c *configer) ImageV2Client(region string) (*gophercloud.ServiceClient, error) {

--- a/vkcs/kubernetes/data_source_addon_test.go
+++ b/vkcs/kubernetes/data_source_addon_test.go
@@ -10,8 +10,12 @@ import (
 
 func TestAccKubernetesAddonDataSource_basic_big(t *testing.T) {
 	var cluster clusters.Cluster
+	uniqueSuffix := acctest.GenerateNameSuffix()
 	baseConfig := acctest.AccTestRenderConfig(testAccKubernetesAddonClusterBase,
-		map[string]string{"TestAccKubernetesAddonNetworkingBase": testAccKubernetesAddonNetworkingBase})
+		map[string]string{"TestAccKubernetesAddonNetworkingBase": testAccKubernetesAddonNetworkingBase,
+			"Suffix":        uniqueSuffix,
+			"NodeGroupName": uniqueKubernetesNodeGroupName(),
+		})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -42,6 +46,6 @@ const testAccKubernetesAddonDataSourceBasic = `
 data "vkcs_kubernetes_addon" "ingress-nginx" {
   cluster_id = vkcs_kubernetes_cluster.cluster.id
   name       = "ingress-nginx"
-  version    = "4.1.4"
+  version    = "4.7.1"
 }
 `

--- a/vkcs/kubernetes/data_source_addons_test.go
+++ b/vkcs/kubernetes/data_source_addons_test.go
@@ -10,8 +10,12 @@ import (
 
 func TestAccKubernetesAddonsDataSource_basic_big(t *testing.T) {
 	var cluster clusters.Cluster
+	uniqueSuffix := acctest.GenerateNameSuffix()
 	baseConfig := acctest.AccTestRenderConfig(testAccKubernetesAddonClusterBase,
-		map[string]string{"TestAccKubernetesAddonNetworkingBase": testAccKubernetesAddonNetworkingBase})
+		map[string]string{"TestAccKubernetesAddonNetworkingBase": testAccKubernetesAddonNetworkingBase,
+			"Suffix":        uniqueSuffix,
+			"NodeGroupName": uniqueKubernetesNodeGroupName(),
+		})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/vkcs/kubernetes/data_source_cluster_template_test.go
+++ b/vkcs/kubernetes/data_source_cluster_template_test.go
@@ -56,7 +56,7 @@ func testAccCheckKubernetesClusterTemplateDataSourceID(n string) resource.TestCh
 
 const testAccKubernetesClusterTemplateDataSourceBasic = `
 data "vkcs_kubernetes_clustertemplate" "template" {
-	version = "1.24"
+	version = "1.27"
 }
 `
 

--- a/vkcs/kubernetes/resource_cluster.go
+++ b/vkcs/kubernetes/resource_cluster.go
@@ -655,7 +655,7 @@ func resourceKubernetesClusterDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending:      []string{string(clusterStatusDeleting), string(clusterStatusDeleted)},
+		Pending:      []string{string(clusterStatusReconciling), string(clusterStatusRunning), string(clusterStatusDeleting), string(clusterStatusDeleted)},
 		Target:       []string{string(clusterStatusNotFound)},
 		Refresh:      kubernetesStateRefreshFunc(client, d.Id()),
 		Timeout:      d.Timeout(schema.TimeoutDelete),

--- a/vkcs/kubernetes/resource_cluster_test.go
+++ b/vkcs/kubernetes/resource_cluster_test.go
@@ -180,7 +180,7 @@ resource "vkcs_networking_router_interface" "base" {
 
 const testAccKubernetesClusterBase = `
 data "vkcs_kubernetes_clustertemplate" "base" {
-  version = "1.24"
+  version = "1.27"
 }
 `
 

--- a/vkcs/kubernetes/resource_node_group_test.go
+++ b/vkcs/kubernetes/resource_node_group_test.go
@@ -104,7 +104,7 @@ data "vkcs_compute_flavor" "base" {
 }
 
 data "vkcs_kubernetes_clustertemplate" "base" {
-  version = "1.24"
+  version = "1.27"
 }
 
 resource "vkcs_kubernetes_cluster" "base" {

--- a/vkcs/networking/data_source_subnet.go
+++ b/vkcs/networking/data_source_subnet.go
@@ -356,5 +356,5 @@ func flattenSubnetDataSourceHostRoutes(_ context.Context, in []subnets.HostRoute
 func expandSubnetDataSourceTags(ctx context.Context, in types.Set, respDiags *diag.Diagnostics) string {
 	var tags []string
 	respDiags.Append(in.ElementsAs(ctx, &tags, true)...)
-	return strings.Join(tags, "")
+	return strings.Join(tags, ",")
 }

--- a/vkcs/networking/data_source_subnet_test.go
+++ b/vkcs/networking/data_source_subnet_test.go
@@ -10,22 +10,24 @@ import (
 )
 
 func TestAccNetworkingSubnetDataSource_basic(t *testing.T) {
+	uniqueTags := acctest.GenerateUniqueTestFields(t.Name())
+	preRenderBaseConfig := acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceSubnet, uniqueTags)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingSubnetDataSourceSubnet,
+				Config: preRenderBaseConfig,
 			},
 			{
-				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceBasic, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": testAccNetworkingSubnetDataSourceSubnet}),
+				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceBasic, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": preRenderBaseConfig}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_1"),
-					testAccCheckNetworkingSubnetDataSourceGoodNetwork("data.vkcs_networking_subnet.subnet_1", "vkcs_networking_network.network_1"),
+					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_acc_test"),
+					testAccCheckNetworkingSubnetDataSourceGoodNetwork("data.vkcs_networking_subnet.subnet_acc_test", "vkcs_networking_network.network_acc_test"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "name", "subnet_1"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "name", "subnet_acc_test"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "all_tags.#", "2"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "all_tags.#", "2"),
 				),
 			},
 		},
@@ -33,6 +35,8 @@ func TestAccNetworkingSubnetDataSource_basic(t *testing.T) {
 }
 
 func TestAccNetworkingSubnetDataSource_migrateToFramework(t *testing.T) {
+	uniqueTags := acctest.GenerateUniqueTestFields(t.Name())
+	preRenderBaseConfig := acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceSubnet, uniqueTags)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { acctest.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
@@ -43,19 +47,19 @@ func TestAccNetworkingSubnetDataSource_migrateToFramework(t *testing.T) {
 						Source:            "vk-cs/vkcs",
 					},
 				},
-				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceBasic, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": testAccNetworkingSubnetDataSourceSubnet}),
+				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceBasic, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": preRenderBaseConfig}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_1"),
-					testAccCheckNetworkingSubnetDataSourceGoodNetwork("data.vkcs_networking_subnet.subnet_1", "vkcs_networking_network.network_1"),
+					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_acc_test"),
+					testAccCheckNetworkingSubnetDataSourceGoodNetwork("data.vkcs_networking_subnet.subnet_acc_test", "vkcs_networking_network.network_acc_test"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "name", "subnet_1"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "name", "subnet_acc_test"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "all_tags.#", "2"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "all_tags.#", "2"),
 				),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
-				Config:                   acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceBasic, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": testAccNetworkingSubnetDataSourceSubnet}),
+				Config:                   acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceBasic, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": preRenderBaseConfig}),
 				PlanOnly:                 true,
 			},
 		},
@@ -63,39 +67,41 @@ func TestAccNetworkingSubnetDataSource_migrateToFramework(t *testing.T) {
 }
 
 func TestAccNetworkingSubnetDataSource_testQueries(t *testing.T) {
+	uniqueTags := acctest.GenerateUniqueTestFields(t.Name())
+	preRenderBaseConfig := acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceSubnet, uniqueTags)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingSubnetDataSourceSubnet,
+				Config: preRenderBaseConfig,
 			},
 			{
-				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceCidr, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": testAccNetworkingSubnetDataSourceSubnet}),
+				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceCidr, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": preRenderBaseConfig}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_1"),
+					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_acc_test"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "description", "my subnet description"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "description", "my subnet description"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "all_tags.#", "2"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "all_tags.#", "2"),
 				),
 			},
 			{
-				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceDhcpEnabled, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": testAccNetworkingSubnetDataSourceSubnet}),
+				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceDhcpEnabled, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": preRenderBaseConfig}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_1"),
+					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_acc_test"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "tags.#", "1"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "all_tags.#", "2"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "all_tags.#", "2"),
 				),
 			},
 			{
-				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceGatewayIP, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": testAccNetworkingSubnetDataSourceSubnet}),
+				Config: acctest.AccTestRenderConfig(testAccNetworkingSubnetDataSourceGatewayIP, map[string]string{"TestAccNetworkingSubnetDataSourceSubnet": preRenderBaseConfig}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_1"),
+					testAccCheckNetworkingSubnetDataSourceID("data.vkcs_networking_subnet.subnet_acc_test"),
 					resource.TestCheckResourceAttr(
-						"data.vkcs_networking_subnet.subnet_1", "all_tags.#", "2"),
+						"data.vkcs_networking_subnet.subnet_acc_test", "all_tags.#", "2"),
 				),
 			},
 		},
@@ -146,19 +152,23 @@ func testAccCheckNetworkingSubnetDataSourceGoodNetwork(n1, n2 string) resource.T
 }
 
 const testAccNetworkingSubnetDataSourceSubnet = `
-resource "vkcs_networking_network" "network_1" {
-  name = "network_1"
+resource "vkcs_networking_network" "network_acc_test" {
+  name = "network_acc_test"
   admin_state_up = "true"
+  tags = [
+	"{{.TestName}}",
+	"{{.CurrentTime}}",
+  ]
 }
 
-resource "vkcs_networking_subnet" "subnet_1" {
-  name = "subnet_1"
+resource "vkcs_networking_subnet" "subnet_acc_test" {
+  name = "subnet_acc_test"
   description = "my subnet description"
   cidr = "192.168.199.0/24"
-  network_id = vkcs_networking_network.network_1.id
+  network_id = vkcs_networking_network.network_acc_test.id
   tags = [
-    "foo",
-    "bar",
+	"{{.TestName}}",
+	"{{.CurrentTime}}",
   ]
 }
 `
@@ -166,36 +176,36 @@ resource "vkcs_networking_subnet" "subnet_1" {
 const testAccNetworkingSubnetDataSourceBasic = `
 {{.TestAccNetworkingSubnetDataSourceSubnet}}
 
-data "vkcs_networking_subnet" "subnet_1" {
-  name = vkcs_networking_subnet.subnet_1.name
+data "vkcs_networking_subnet" "subnet_acc_test" {
+  name = vkcs_networking_subnet.subnet_acc_test.name
+  tags = vkcs_networking_subnet.subnet_acc_test.tags
 }
 `
 
 const testAccNetworkingSubnetDataSourceCidr = `
 {{.TestAccNetworkingSubnetDataSourceSubnet}}
 
-data "vkcs_networking_subnet" "subnet_1" {
+data "vkcs_networking_subnet" "subnet_acc_test" {
   cidr = "192.168.199.0/24"
-  tags = []
+  tags = vkcs_networking_subnet.subnet_acc_test.tags
 }
 `
 
 const testAccNetworkingSubnetDataSourceDhcpEnabled = `
 {{.TestAccNetworkingSubnetDataSourceSubnet}}
 
-data "vkcs_networking_subnet" "subnet_1" {
-  network_id = vkcs_networking_network.network_1.id
+data "vkcs_networking_subnet" "subnet_acc_test" {
+  network_id = vkcs_networking_network.network_acc_test.id
   dhcp_enabled = true
-  tags = [
-    "bar",
-  ]
+  tags = vkcs_networking_subnet.subnet_acc_test.tags
 }
 `
 
 const testAccNetworkingSubnetDataSourceGatewayIP = `
 {{.TestAccNetworkingSubnetDataSourceSubnet}}
 
-data "vkcs_networking_subnet" "subnet_1" {
-  gateway_ip = vkcs_networking_subnet.subnet_1.gateway_ip
+data "vkcs_networking_subnet" "subnet_acc_test" {
+  gateway_ip = vkcs_networking_subnet.subnet_acc_test.gateway_ip
+  tags = vkcs_networking_subnet.subnet_acc_test.tags
 }
 `


### PR DESCRIPTION
work in progress
Fix: 
- fix finding by tag of subnet
- add unique tags for subnets in tests
- fix kuber template cluster version
- fix instance shelved and unshelved operations
- set api version for all compute instance operations