### PR TITLE
Fix an error with filter on pool name in fip data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ description: |-
 #### v0.8.1 (unreleased)
 - Add "k8s_config" attribute to vkcs_kubernetes_cluster resource
 - Fix order-induced changes in the plan for "allowed_cidrs" of the vkcs_lb_listener resource
+- Fix an error when filtering by pool name in the vkcs_networking_floatingip data source in SDN Sprut
 
 #### v0.8.0
 - Add vkcs_dc_conntrack_helper resource

--- a/vkcs/networking/data_source_floatingip.go
+++ b/vkcs/networking/data_source_floatingip.go
@@ -20,54 +20,63 @@ func DataSourceNetworkingFloatingIP() *schema.Resource {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The region in which to obtain the Network client. A Network client is needed to retrieve floating IP ids. If omitted, the `region` argument of the provider is used.",
 			},
 
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Human-readable description of the floating IP.",
 			},
 
 			"address": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The IP address of the floating IP.",
 			},
 
 			"pool": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of the pool from which the floating IP belongs to.",
 			},
 
 			"port_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The ID of the port the floating IP is attached.",
 			},
 
 			"tenant_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The owner of the floating IP.",
 			},
 
 			"fixed_ip": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The specific IP address of the internal port which should be associated with the floating IP.",
 			},
 
 			"status": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Status of the floating IP (ACTIVE/DOWN).",
 			},
 
 			"sdn": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				ValidateDiagFunc: ValidateSDN(),
 				Description:      "SDN to use for this resource. Must be one of following: \"neutron\", \"sprut\". Default value is project's default SDN.",
 			},
@@ -104,7 +113,15 @@ func dataSourceNetworkingFloatingIPRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if v, ok := d.GetOk("pool"); ok {
-		listOpts.FloatingNetworkID = v.(string)
+		poolName := v.(string)
+		poolID, err := networkingNetworkID(d, meta, poolName)
+		if err != nil {
+			return diag.Errorf("Error retrieving ID for vkcs_networking_floatingip pool %q: %s", poolName, err)
+		}
+		if poolID == "" {
+			return diag.Errorf("Unable to find network with name %q", poolName)
+		}
+		listOpts.FloatingNetworkID = poolID
 	}
 
 	if v, ok := d.GetOk("port_id"); ok {

--- a/vkcs/networking/data_source_floatingip_test.go
+++ b/vkcs/networking/data_source_floatingip_test.go
@@ -9,18 +9,20 @@ import (
 	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
 )
 
-func TestAccNetworkingFloatingIPV2DataSource_address(t *testing.T) {
+func TestAccNetworkingFloatingIPDataSource_address(t *testing.T) {
+	baseConfig := acctest.AccTestRenderConfig(testAccNetworkingFloatingIPDataSourceBase)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.AccTestPreCheck(t) },
 		ProviderFactories: acctest.AccTestProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.AccTestRenderConfig(testAccNetworkingFloatingIPV2DataSourceFloatingIP),
+				Config: baseConfig,
 			},
 			{
-				Config: acctest.AccTestRenderConfig(testAccNetworkingFloatingIPV2DataSourceAddress, map[string]string{"TestAccNetworkingFloatingIPV2DataSourceFloatingIP": acctest.AccTestRenderConfig(testAccNetworkingFloatingIPV2DataSourceFloatingIP)}),
+				Config: acctest.AccTestRenderConfig(testAccNetworkingFloatingIPDataSourceAddress, map[string]string{"TestAccNetworkingFloatingIPDataSourceFloatingIPBase": baseConfig}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingFloatingIPV2DataSourceID("data.vkcs_networking_floatingip.fip_1"),
+					testAccCheckNetworkingFloatingIPDataSourceID("data.vkcs_networking_floatingip.fip_1"),
 					resource.TestCheckResourceAttrSet(
 						"data.vkcs_networking_floatingip.fip_1", "address"),
 					resource.TestCheckResourceAttrSet(
@@ -35,7 +37,7 @@ func TestAccNetworkingFloatingIPV2DataSource_address(t *testing.T) {
 	})
 }
 
-func testAccCheckNetworkingFloatingIPV2DataSourceID(n string) resource.TestCheckFunc {
+func testAccCheckNetworkingFloatingIPDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -50,18 +52,17 @@ func testAccCheckNetworkingFloatingIPV2DataSourceID(n string) resource.TestCheck
 	}
 }
 
-const testAccNetworkingFloatingIPV2DataSourceFloatingIP = `
+const testAccNetworkingFloatingIPDataSourceBase = `
 resource "vkcs_networking_floatingip" "fip_1" {
-  pool = "{{.ExtNetName}}"
-  description = "test fip"
+  pool        = "{{ .ExtNetName }}"
+  description = "tfacc-fip"
 }
 `
 
-const testAccNetworkingFloatingIPV2DataSourceAddress = `
-{{.TestAccNetworkingFloatingIPV2DataSourceFloatingIP}}
+const testAccNetworkingFloatingIPDataSourceAddress = `
+{{ .TestAccNetworkingFloatingIPDataSourceFloatingIPBase }}
 
 data "vkcs_networking_floatingip" "fip_1" {
   address = vkcs_networking_floatingip.fip_1.address
-  description = "test fip"
 }
 `


### PR DESCRIPTION
Before this patch, pool name was passed as network id to search in. And, since it was in the wrong format for the UUID, it was ignored in Neutron and caused an error in Sprut. Now we retrieve network id by its name, as we do in the resource for floating IP, and use it in the corresponding filter.

VKPRGM-736