### PR TITLE
add last error to timeout error, when deleting subnet

### DIFF
--- a/vkcs/networking/network.go
+++ b/vkcs/networking/network.go
@@ -103,7 +103,7 @@ func networkingNetworkName(d *schema.ResourceData, meta interface{}, networkID s
 	return networkName, err
 }
 
-func resourceNetworkingNetworkStateRefreshFunc(client *gophercloud.ServiceClient, networkID string) retry.StateRefreshFunc {
+func resourceNetworkingNetworkStateRefreshFunc(client *gophercloud.ServiceClient, networkID string, errDetails *error) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		n, err := inetworks.Get(client, networkID).Extract()
 		if err != nil {
@@ -111,6 +111,7 @@ func resourceNetworkingNetworkStateRefreshFunc(client *gophercloud.ServiceClient
 				return n, "DELETED", nil
 			}
 			if errutil.Is(err, 409) {
+				*errDetails = err
 				return n, "ACTIVE", nil
 			}
 

--- a/vkcs/networking/router_interface.go
+++ b/vkcs/networking/router_interface.go
@@ -28,7 +28,7 @@ func resourceNetworkingRouterInterfaceStateRefreshFunc(networkingClient *gopherc
 	}
 }
 
-func resourceNetworkingRouterInterfaceDeleteRefreshFunc(networkingClient *gophercloud.ServiceClient, d *schema.ResourceData) retry.StateRefreshFunc {
+func resourceNetworkingRouterInterfaceDeleteRefreshFunc(networkingClient *gophercloud.ServiceClient, d *schema.ResourceData, deleteErrDetails *error) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		routerID := d.Get("router_id").(string)
 		routerInterfaceID := d.Id()
@@ -63,6 +63,7 @@ func resourceNetworkingRouterInterfaceDeleteRefreshFunc(networkingClient *gopher
 			}
 			if errutil.Is(err, 409) {
 				log.Printf("[DEBUG] vkcs_networking_router_interface %s is still in use", routerInterfaceID)
+				*deleteErrDetails = err
 				return r, "ACTIVE", nil
 			}
 


### PR DESCRIPTION
Old error:
Error: Error waiting for vkcs_networking_subnet <subnet_id> to become deleted: timeout while waiting for state to become 'DELETED' (last state: 'DELETED', timeout: 10m)
New error:
 Error: Error waiting for vkcs_networking_subnet <subnet_id> to become deleted: timeout while waiting for state to become 'DELETED' (last state: 'ACTIVE', timeout: 10m): Expected HTTP response code [202 204] when accessing [DELETE https://infra.mail.ru:9696/v2.0/subnets/3f915ba7-d900-466a-a8f8-162ed37047c6], but got 409 instead
{"NeutronError": {"message": "Duplicate parameters for '<class 'sprut.dm.neutron_models.IpPool'>'. Original message: One or more ports have an IP allocation from IpPool <IpPool_id>", "type": "HTTPConflict", "detail": ""}}
Request ID: <req_id>

