### PR TITLE
Fix blockstorage volume online retyping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ description: |-
 # VKCS Provider's changelog
 
 #### v0.8.3 (unreleased)
-- Fix changing the volume_type of the vkcs_blockstorage_volume resource when it is connected to a compute instance
+- Fix unexpected state error when updating volume_type of attached vkcs_blocstorage_volume
 
 #### v0.8.2
 - Add retry on duplicate IpamAllocation error when creating a networking router

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ description: |-
 # VKCS Provider's changelog
 
 #### v0.8.3 (unreleased)
+- Fix changing the volume_type of the vkcs_blockstorage_volume resource when it is connected to a compute instance
 
 #### v0.8.2
 - Add retry on duplicate IpamAllocation error when creating a networking router

--- a/vkcs/blockstorage/resource_volume.go
+++ b/vkcs/blockstorage/resource_volume.go
@@ -29,6 +29,7 @@ var (
 	BSVolumeStatusInUse       = "in-use"
 	BSVolumeStatusDetaching   = "detaching"
 	bsVolumeStatusRetype      = "retyping"
+	bsVolumeStatusAttaching   = "attaching"
 	bsVolumeStatusShutdown    = "deleting"
 	bsVolumeStatusDeleted     = "deleted"
 	bsVolumeStatusDownloading = "downloading"
@@ -269,7 +270,7 @@ func resourceBlockStorageVolumeUpdate(ctx context.Context, d *schema.ResourceDat
 			return diag.Errorf("error changing type of vkcs_blockstorage_volume %s", d.Id())
 		}
 		stateConf := &retry.StateChangeConf{
-			Pending:    []string{bsVolumeStatusBuild, bsVolumeStatusRetype},
+			Pending:    []string{bsVolumeStatusBuild, bsVolumeStatusRetype, bsVolumeStatusAttaching},
 			Target:     []string{BSVolumeStatusActive, BSVolumeStatusInUse},
 			Refresh:    BlockStorageVolumeStateRefreshFunc(blockStorageClient, d.Id()),
 			Timeout:    d.Timeout(schema.TimeoutCreate),

--- a/vkcs/blockstorage/resource_volume_test.go
+++ b/vkcs/blockstorage/resource_volume_test.go
@@ -122,14 +122,14 @@ func TestAccBlockStorageVolume_online_retype(t *testing.T) {
 		CheckDestroy:      testAccCheckBlockStorageVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.AccTestRenderConfig(testAccBlockStorageVolumeOnlineRetype),
+				Config: acctest.AccTestRenderConfig(testAccBlockStorageVolumeOnlineRetype, map[string]string{"VolumeType": "ceph-hdd"}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"vkcs_blockstorage_volume.bootable", "volume_type", "ceph-hdd"),
 				),
 			},
 			{
-				Config: acctest.AccTestRenderConfig(testAccBlockStorageVolumeOnlineRetypeUpdate),
+				Config: acctest.AccTestRenderConfig(testAccBlockStorageVolumeOnlineRetype, map[string]string{"VolumeType": "ceph-ssd"}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"vkcs_blockstorage_volume.bootable", "volume_type", "ceph-ssd"),
@@ -332,33 +332,7 @@ const testAccBlockStorageVolumeOnlineRetype = `
 resource "vkcs_blockstorage_volume" "bootable" {
   name              = "bootable-tf-acc"
   size              = 10
-  volume_type       = "ceph-hdd"
-  image_id          = data.vkcs_images_image.base.id
-  availability_zone = "GZ1"
-}
-
-resource "vkcs_compute_instance" "basic" {
-  name 				= "instance_tf_acc"
-  flavor_name       = "{{.FlavorName}}"
-
-  block_device {
-    boot_index       = 0
-    source_type      = "volume"
-    destination_type = "volume"
-    uuid             = vkcs_blockstorage_volume.bootable.id
-  }
-
-   network_mode  = "none"
-}
-`
-
-const testAccBlockStorageVolumeOnlineRetypeUpdate = `
-{{.BaseImage}}
-
-resource "vkcs_blockstorage_volume" "bootable" {
-  name              = "bootable-tf-acc"
-  size              = 10
-  volume_type       = "ceph-ssd"
+  volume_type       = "{{.VolumeType}}"
   image_id          = data.vkcs_images_image.base.id
   availability_zone = "GZ1"
 }


### PR DESCRIPTION
Fix changing the volume_type of the vkcs_blockstorage_volume resource when it is connected to a compute instance