### PR TITLE
Fix redundant plan changes for availability_zones of vkcs_kubernetes_cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ description: |-
 
 # VKCS Provider's changelog
 
+#### v0.8.4 (unreleased)
+- Fix forced re-creation of the vkcs_kubernetes_cluster due to redundant planned changes for availability_zones argument
+
 #### v0.8.3
 - Add ability to choose type of kubernetes cluster, standard or regional
 - Add cluster_type and availability_zones argument to vkcs_kubernetes_cluster

--- a/vkcs/kubernetes/resource_cluster.go
+++ b/vkcs/kubernetes/resource_cluster.go
@@ -473,13 +473,8 @@ func resourceKubernetesClusterRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("dns_domain", cluster.DNSDomain)
 	d.Set("sync_security_policy", cluster.SecurityPolicySyncEnabled)
 	d.Set("cluster_type", cluster.ClusterType)
-
-	switch cluster.ClusterType {
-	case clusterTypeStandard:
-		d.Set("availability_zone", cluster.AvailabilityZone)
-	case clusterTypeRegional:
-		d.Set("availability_zones", cluster.AvailabilityZones)
-	}
+	d.Set("availability_zone", cluster.AvailabilityZone)
+	d.Set("availability_zones", cluster.AvailabilityZones)
 
 	k8sConfig, err := clusters.KubeConfigGet(containerInfraClient, cluster.UUID)
 	if err != nil {


### PR DESCRIPTION
An upgrade of the provider to version 0.8.3 leads to forced recreation of the vkcs_kubernetes_cluster resource in the Terraform plan. This was due to a missing "availability_zones" attribute in the state for the cluster resource.

VKPRGM-1254