### PR TITLE
Fix provider version in audit log

### DIFF
--- a/vkcs/internal/clients/config.go
+++ b/vkcs/internal/clients/config.go
@@ -102,7 +102,7 @@ func ConfigureSdkProvider(d *schema.ResourceData, terraformVersion string) (Conf
 		return nil, sdkdiag.FromErr(err)
 	}
 
-	config.OsClient.UserAgent.Prepend(fmt.Sprintf("VKCS Terraform Provider %s", version.ProviderVersion))
+	config.OsClient.UserAgent.Prepend(fmt.Sprintf("VKCS Terraform Provider/%s", version.ProviderVersion))
 	config.OsClient.RetryFunc = retryFunc
 
 	return config, nil
@@ -285,7 +285,7 @@ func ConfigureProvider(ctx context.Context, req provider.ConfigureRequest) (Conf
 		return nil, diags
 	}
 
-	config.OsClient.UserAgent.Prepend(fmt.Sprintf("VKCS Terraform Provider %s", version.ProviderVersion))
+	config.OsClient.UserAgent.Prepend(fmt.Sprintf("VKCS Terraform Provider/%s", version.ProviderVersion))
 	config.OsClient.RetryFunc = retryFunc
 
 	return &config, diags


### PR DESCRIPTION
Now log will be:
VKCS Terraform Provider/dev HashiCorp Terraform/1.10.0 (+https://www.terraform.io) Terraform Plugin SDK/2.10.1 HashiCorp-terraform-exec/0.18.1 gophercloud/2.0.0