### PR TITLE
Disable forced re-creation to update the cloud_monitoring_enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ description: |-
 # VKCS Provider's changelog
 
 #### v0.9.4 (unreleased)
+- Disable forced re-creation when updating cloud_monitoring_enabled for the vkcs_db_instance with MongoDB datastore type
 
 #### v0.9.3
 - Add secure_key option to cdn resource

--- a/docs/resources/db_cluster.md
+++ b/docs/resources/db_cluster.md
@@ -187,7 +187,7 @@ output "cluster_ip" {
 
   - `settings` optional *map of* *string* &rarr;  Map of key-value settings of the capability.
 
-- `cloud_monitoring_enabled` optional *boolean* &rarr;  Enable cloud monitoring for the cluster. Changing this for Redis or MongoDB creates a new instance.<br>**New since v0.2.0**.
+- `cloud_monitoring_enabled` optional *boolean* &rarr;  Enable cloud monitoring for the cluster.<br>**New since v0.2.0**.
 
 - `configuration_id` optional *string* &rarr;  The id of the configuration attached to cluster.
 

--- a/docs/resources/db_cluster_with_shards.md
+++ b/docs/resources/db_cluster_with_shards.md
@@ -160,7 +160,7 @@ resource "vkcs_db_cluster_with_shards" "db_cluster_with_shards" {
 
   - `settings` optional *map of* *string* &rarr;  Map of key-value settings of the capability.
 
-- `cloud_monitoring_enabled` optional *boolean* &rarr;  Enable cloud monitoring for the cluster. Changing this for Redis or MongoDB creates a new instance.<br>**New since v0.2.0**.
+- `cloud_monitoring_enabled` optional *boolean* &rarr;  Enable cloud monitoring for the cluster.<br>**New since v0.2.0**.
 
 - `configuration_id` optional *string* &rarr;  The id of the configuration attached to cluster.
 

--- a/docs/resources/db_instance.md
+++ b/docs/resources/db_instance.md
@@ -162,7 +162,7 @@ resource "vkcs_db_instance" "pg_with_backup" {
 
   - `settings` optional *map of* *string* &rarr;  Map of key-value settings of the capability.
 
-- `cloud_monitoring_enabled` optional *boolean* &rarr;  Enable cloud monitoring for the instance. Changing this for Redis or MongoDB creates a new instance.<br>**New since v0.2.0**.
+- `cloud_monitoring_enabled` optional *boolean* &rarr;  Enable cloud monitoring for the instance. Changing this for Redis creates a new instance.<br>**New since v0.2.0**.
 
 - `configuration_id` optional *string* &rarr;  The id of the configuration attached to instance.
 

--- a/vkcs/db/resource_cluster.go
+++ b/vkcs/db/resource_cluster.go
@@ -427,7 +427,7 @@ func ResourceDatabaseCluster() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Enable cloud monitoring for the cluster. Changing this for Redis or MongoDB creates a new instance.",
+				Description: "Enable cloud monitoring for the cluster.",
 			},
 
 			"vendor_options": {

--- a/vkcs/db/resource_cluster_with_shards.go
+++ b/vkcs/db/resource_cluster_with_shards.go
@@ -253,7 +253,7 @@ func ResourceDatabaseClusterWithShards() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Enable cloud monitoring for the cluster. Changing this for Redis or MongoDB creates a new instance.",
+				Description: "Enable cloud monitoring for the cluster.",
 			},
 
 			"shard": {

--- a/vkcs/db/resource_instance.go
+++ b/vkcs/db/resource_instance.go
@@ -445,7 +445,7 @@ func ResourceDatabaseInstance() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "Enable cloud monitoring for the instance. Changing this for Redis or MongoDB creates a new instance.",
+				Description: "Enable cloud monitoring for the instance. Changing this for Redis creates a new instance.",
 			},
 
 			"vendor_options": {

--- a/vkcs/db/shared.go
+++ b/vkcs/db/shared.go
@@ -10,13 +10,13 @@ import (
 	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util"
 )
 
-func resourceDatabaseCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func resourceDatabaseCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 	if diff.Id() != "" && diff.HasChange("cloud_monitoring_enabled") {
 		t, exists := diff.GetOk("datastore.0.type")
 		if !exists {
 			return errors.New("datastore.0.type is not found")
 		}
-		if exists && util.IsOperationNotSupported(t.(string), Redis, MongoDB) {
+		if util.IsOperationNotSupported(t.(string), Redis) {
 			return diff.ForceNew("cloud_monitoring_enabled")
 		}
 	}


### PR DESCRIPTION
VKPRGM-2335  Disable forced re-creation when updating cloud_monitoring_enabled for the vkcs_db_instance with MongoDB datastore type