### PR TITLE
fix terraform import data bug with empty uuid for volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ description: |-
 # VKCS Provider's changelog
 #### v0.11.2 (unreleased)
 - Support stack_id parameter for vkcs_dataplatform_cluster creation
+- Fix data when importing a VM via terraform. Added separation into image and volume for uuid and source_type
 
 #### v0.11.1
 - Fix updating wal_disk_autoexpand field of resource vkcs_database_cluster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ description: |-
 # VKCS Provider's changelog
 #### v0.11.2 (unreleased)
 - Support stack_id parameter for vkcs_dataplatform_cluster creation
-- Fix data when importing a VM via terraform. Added separation into image and volume for uuid and source_type
+- Fix imporitng VM booted on a disk was not created from an image
 
 #### v0.11.1
 - Fix updating wal_disk_autoexpand field of resource vkcs_database_cluster

--- a/vkcs/compute/resource_instance.go
+++ b/vkcs/compute/resource_instance.go
@@ -1290,33 +1290,31 @@ func resourceComputeInstanceImportState(ctx context.Context, d *schema.ResourceD
 
 			log.Printf("[DEBUG] retrieved volume%+v", volMetaData)
 
-			var uuid, sourceType string
-			if imageID, ok := volMetaData.VolumeImageMetadata["image_id"]; ok && imageID != "" {
-				uuid = imageID.(string)
-				sourceType = "image"
-			} else {
-				uuid = volMetaData.ID
-				sourceType = "volume"
-			}
-
 			v := map[string]interface{}{
 				"delete_on_termination": true,
-				"uuid":                  uuid,
 				"boot_index":            -1,
 				"destination_type":      "volume",
-				"source_type":           sourceType,
-				"volume_size":           volMetaData.Size,
 				"disk_bus":              "",
-				"volume_type":           volMetaData.VolumeType,
 				"device_type":           "",
+			}
+
+			if imageID, ok := volMetaData.VolumeImageMetadata["image_id"]; ok && imageID != "" {
+				v["uuid"] = imageID.(string)
+				v["source_type"] = "image"
+				v["volume_size"] = volMetaData.Size
+				v["volume_type"] = volMetaData.VolumeType
+			} else {
+				v["uuid"] = volMetaData.ID
+				v["source_type"] = "volume"
 			}
 
 			if volMetaData.Bootable == "true" {
 				bds = append(bds, v)
 			}
 		}
-
-		bds[0]["boot_index"] = 0
+		if len(bds) != 0 {
+			bds[0]["boot_index"] = 0
+		}
 
 		d.Set("block_device", bds)
 	}

--- a/vkcs/compute/resource_instance_test.go
+++ b/vkcs/compute/resource_instance_test.go
@@ -1119,6 +1119,7 @@ resource "vkcs_compute_instance" "instance_1" {
     boot_index = 0
     destination_type = "volume"
     delete_on_termination = true
+	volume_type = "ceph-hdd"
   }
   network {
     uuid = vkcs_networking_network.base.id
@@ -1178,6 +1179,7 @@ resource "vkcs_compute_instance" "instance_1" {
     boot_index = 0
     destination_type = "volume"
     delete_on_termination = true
+	volume_type = "ceph-hdd"
   }
   network {
     uuid = vkcs_networking_network.base.id


### PR DESCRIPTION
VKCSDEV-16873
Fix data when importing a VM via terraform. Added separation into image and volume for uuid and source_type.