### PR TITLE
Fix vkcs_db_user lookup to avoid pagination 404 when >20 users

### DIFF
--- a/vkcs/internal/services/db/v1/users/requests.go
+++ b/vkcs/internal/services/db/v1/users/requests.go
@@ -77,6 +77,16 @@ func List(client *gophercloud.ServiceClient, id string, dbmsType string) paginat
 	})
 }
 
+// Get performs request to get database user
+func Get(client *gophercloud.ServiceClient, id string, name string, dbmsType string) (r GetResult) {
+	resp, err := client.Get(userURL(client, dbmsType, id, name), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
 // Update performs request to update database user
 func Update(client *gophercloud.ServiceClient, id string, name string, opts OptsBuilder, dbmsType string) (r UpdateResult) {
 	b, err := opts.Map()


### PR DESCRIPTION
  Problem
  - Terraform apply fails for vkcs_db_user when there are more than ~20 DB users.
  - The provider uses List + pagination, and the VKCS API returns 404 for marker-based pagination (GET .../users?marker=...).

  Fix
  - Switched user existence checks and state refresh from list pagination to direct GET by user name.
  - This removes the marker pagination call that triggers 404.

  Impact
  - vkcs_db_user read/create/update now works with any number of users.
  - No changes to resource schema or user-facing configuration.

  Notes
  - If the API returns 404 for a missing user, it is now treated as “not found” instead of erroring.