### PR TITLE
Add initial Bare Metal support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -100,6 +100,9 @@ testmock_k8saas: fmtcheck
 testacc_k8saas: fmtcheck
 	TF_ACC=1 go test -run=TestAccKubernetes $(TEST) $(TESTARGS) -timeout 120m
 
+testacc_bmaas: fmtcheck
+	TF_ACC=1 go test -run='TestAccBareMetal|TestManualAccBareMetal' $(TEST) $(TESTARGS) -timeout 120m
+
 vet:
 	@echo "go vet ."
 	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \

--- a/docs/data-sources/baremetal_flavor.md
+++ b/docs/data-sources/baremetal_flavor.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Baremetal"
+layout: "vkcs"
+page_title: "vkcs: vkcs_baremetal_flavor"
+description: |-
+  Get information on a VKCS bare metal flavor.
+---
+
+# vkcs_baremetal_flavor
+
+Use this data source to get information about a VKCS Baremetal Flavor.
+
+## Example Usage
+
+```terraform
+data "vkcs_baremetal_flavor" "main" {
+  name              = "BM_CX301_N_BOND"
+  cpu_model         = "Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz"
+  cpu_cores         = 32
+  ram_size          = 128
+  ssd_size          = 900
+  hdd_size          = 16000
+  bond_vlan_capable = true
+}
+
+output "flavor_output" {
+  value = {
+    id                = data.vkcs_baremetal_flavor.main.id
+    name              = data.vkcs_baremetal_flavor.main.name
+    cpu_cores         = data.vkcs_baremetal_flavor.main.cpu_cores
+    ram_size          = data.vkcs_baremetal_flavor.main.ram_size
+    ssd_size          = data.vkcs_baremetal_flavor.main.ssd_size
+    hdd_size          = data.vkcs_baremetal_flavor.main.hdd_size
+    bond_vlan_capable = data.vkcs_baremetal_flavor.main.bond_vlan_capable
+  }
+}
+```
+
+## Argument Reference
+- `bond_vlan_capable` optional *boolean* &rarr;  Bond and VLAN capable.
+
+- `cpu_cores` optional *number* &rarr;  CPU core count including hyper-threading.
+
+- `cpu_model` optional *string* &rarr;  The CPU model.
+
+- `hdd_size` optional *number* &rarr;  HDD size in gigabytes.
+
+- `id` optional *string* &rarr;  The UUID of the flavor.
+
+- `name` optional *string* &rarr;  The name of the flavor.
+
+- `ram_size` optional *number* &rarr;  RAM in gigabytes.
+
+- `region` optional *string* &rarr;  The region to fetch the bare metal flavor from, defaults to the provider's region.
+
+- `ssd_size` optional *number* &rarr;  SSD size in gigabytes.
+
+
+## Attributes Reference
+No additional attributes are exported.
+

--- a/docs/data-sources/baremetal_flavor.md
+++ b/docs/data-sources/baremetal_flavor.md
@@ -27,6 +27,7 @@ output "flavor_output" {
   value = {
     id                = data.vkcs_baremetal_flavor.main.id
     name              = data.vkcs_baremetal_flavor.main.name
+    display_name      = data.vkcs_baremetal_flavor.main.display_name
     cpu_cores         = data.vkcs_baremetal_flavor.main.cpu_cores
     ram_size          = data.vkcs_baremetal_flavor.main.ram_size
     ssd_size          = data.vkcs_baremetal_flavor.main.ssd_size
@@ -57,5 +58,7 @@ output "flavor_output" {
 
 
 ## Attributes Reference
-No additional attributes are exported.
+In addition to all arguments above, the following attributes are exported:
+- `display_name` *string* &rarr;  The project-specific display name of the flavor.
+
 

--- a/docs/data-sources/baremetal_flavors.md
+++ b/docs/data-sources/baremetal_flavors.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Baremetal"
+layout: "vkcs"
+page_title: "vkcs: vkcs_baremetal_flavors"
+description: |-
+  Get information on VKCS bare metal flavors.
+---
+
+# vkcs_baremetal_flavors
+
+Use this data source to get a list of available VKCS Baremetal Flavors.
+
+## Example Usage
+
+```terraform
+data "vkcs_baremetal_flavors" "main" {}
+
+output "flavors_output" {
+  value = {
+    flavors = data.vkcs_baremetal_flavors.main
+  }
+}
+```
+
+## Argument Reference
+- `region` optional *string* &rarr;  The region to fetch the bare metal flavor from, defaults to the provider's region.
+
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+- `flavors`  *list* &rarr;  Available Baremetal Flavors.
+    - `bond_vlan_capable` *boolean* &rarr;  Bond and VLAN capable.
+
+    - `cpu_cores` *number* &rarr;  CPU core count including hyper-threading.
+
+    - `cpu_model` *string* &rarr;  The CPU model.
+
+    - `hdd_size` *number* &rarr;  HDD size in gigabytes.
+
+    - `name` *string* &rarr;  The name of the flavor.
+
+    - `ram_size` *number* &rarr;  RAM in gigabytes.
+
+    - `ssd_size` *number* &rarr;  SSD size in gigabytes.
+
+
+

--- a/docs/data-sources/baremetal_flavors.md
+++ b/docs/data-sources/baremetal_flavors.md
@@ -35,6 +35,8 @@ In addition to all arguments above, the following attributes are exported:
 
     - `cpu_model` *string* &rarr;  The CPU model.
 
+    - `display_name` *string* &rarr;  The project-specific display name of the flavor.
+
     - `hdd_size` *number* &rarr;  HDD size in gigabytes.
 
     - `name` *string* &rarr;  The name of the flavor.

--- a/docs/data-sources/baremetal_os.md
+++ b/docs/data-sources/baremetal_os.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Baremetal"
+layout: "vkcs"
+page_title: "vkcs: vkcs_baremetal_os"
+description: |-
+  Get information on a VKCS bare metal operating system.
+---
+
+# vkcs_baremetal_os
+
+Use this data source to get information about a VKCS baremetal OS.
+
+## Example Usage
+
+```terraform
+data "vkcs_baremetal_os" "ubuntu" {
+  name      = "ubuntu"
+  version   = "24.04"
+  raid_type = "RAID1"
+}
+
+output "flavor_output" {
+  value = {
+    id        = data.vkcs_baremetal_os.ubuntu.id
+    name      = data.vkcs_baremetal_os.ubuntu.name
+    version   = data.vkcs_baremetal_os.ubuntu.version
+    raid_type = data.vkcs_baremetal_os.ubuntu.raid_type
+  }
+}
+```
+
+## Argument Reference
+- `id` optional *string* &rarr;  The UUID of the OS.
+
+- `name` optional *string* &rarr;  The name of the OS.
+
+- `raid_type` optional *string* &rarr;  The raid type of the OS.
+
+- `region` optional *string* &rarr;  The region to fetch the bare metal OS from, defaults to the provider's region.
+
+- `version` optional *string* &rarr;  The version of the OS.
+
+
+## Attributes Reference
+No additional attributes are exported.
+

--- a/docs/data-sources/baremetal_oses.md
+++ b/docs/data-sources/baremetal_oses.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Baremetal"
+layout: "vkcs"
+page_title: "vkcs: vkcs_baremetal_oses"
+description: |-
+  Get information on VKCS bare metal operating systems.
+---
+
+# vkcs_baremetal_oses
+
+Use this data source to get a list of available VKCS Baremetal OSes.
+
+## Example Usage
+
+```terraform
+data "vkcs_baremetal_oses" "main" {}
+
+output "oses_output" {
+  value = {
+    oses = data.vkcs_baremetal_oses.main
+  }
+}
+```
+
+## Argument Reference
+- `region` optional *string* &rarr;  The region to fetch the bare metal OSes from, defaults to the provider's region.
+
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+- `oses`  *list* &rarr;  Available Baremetal OSes.
+    - `name` *string* &rarr;  The name of the OS.
+
+    - `raid_type` *string* &rarr;  The raid type of the OS.
+
+    - `version` *string* &rarr;  The version of the OS.
+
+
+

--- a/docs/data-sources/baremetal_server.md
+++ b/docs/data-sources/baremetal_server.md
@@ -1,0 +1,124 @@
+---
+subcategory: "Baremetal"
+layout: "vkcs"
+page_title: "vkcs: vkcs_baremetal_server"
+description: |-
+  Get information on a VKCS bare metal server.
+---
+
+# vkcs_baremetal_server
+
+Use this data source to get information about a VKCS bare metal server.
+
+## Example Usage
+
+```terraform
+data "vkcs_baremetal_server" "server" {
+  id = vkcs_baremetal_server.server.id
+}
+
+output "server_output" {
+  value = {
+    id                = data.vkcs_baremetal_server.server.id
+    name              = data.vkcs_baremetal_server.server.name
+    region            = data.vkcs_baremetal_server.server.region
+    availability_zone = data.vkcs_baremetal_server.server.availability_zone
+
+    cpu_cores = data.vkcs_baremetal_server.server.cpu_cores
+    cpu_types = data.vkcs_baremetal_server.server.cpu_types
+
+    is_locked = data.vkcs_baremetal_server.server.is_locked
+
+    local_disk_sizes = data.vkcs_baremetal_server.server.local_disk_sizes
+    ram_megabytes    = data.vkcs_baremetal_server.server.ram_megabytes
+
+    power_state = data.vkcs_baremetal_server.server.power_state
+    status      = data.vkcs_baremetal_server.server.status
+
+    tags = data.vkcs_baremetal_server.server.tags
+
+    image_id   = data.vkcs_baremetal_server.server.image_id
+    image_name = data.vkcs_baremetal_server.server.image_name
+    os_type    = data.vkcs_baremetal_server.server.os_type
+
+    raid_type = data.vkcs_baremetal_server.server.raid_type
+    flavor_id = data.vkcs_baremetal_server.server.flavor_id
+
+    target_boot_order = data.vkcs_baremetal_server.server.target_boot_order
+
+    local_disks_info = data.vkcs_baremetal_server.server.local_disks_info
+  }
+}
+
+output "boot_devices" {
+  value = [
+    for b in data.vkcs_baremetal_server.server.target_boot_order :
+    b.boot_device_type
+  ]
+}
+
+output "disks" {
+  value = [
+    for d in data.vkcs_baremetal_server.server.local_disks_info : {
+      path  = d.path
+      size  = d.size
+      type  = d.type
+      model = d.model
+    }
+  ]
+}
+```
+
+## Argument Reference
+- `id` **required** *string* &rarr;  The UUID of the bare metal server.
+
+- `region` optional *string* &rarr;  The region to fetch the bare metal server from, defaults to the provider's region.
+
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+- `availability_zone` *string* &rarr;  The availability zone of this server.
+
+- `cpu_cores` *number* &rarr;  CPU core count including hyper-threading.
+
+- `cpu_types` *string* &rarr;  Server CPU type.
+
+- `flavor_id` *string* &rarr;  Flavor ID of the server.
+
+- `image_id` *string* &rarr;  The image ID used to create the server.
+
+- `image_name` *string* &rarr;  The image name used to create the server.
+
+- `is_locked` *boolean* &rarr;  Shows whether the server is protected. The server cannot be deleted while this flag is set.
+
+- `local_disk_sizes` *number* &rarr;  Local disk sizes in gigabytes.
+
+- `local_disks_info`  *list* &rarr;  Information about server disks.
+    - `model` *string* &rarr;  The model of the disk.
+
+    - `path` *string* &rarr;  The path to the disk.
+
+    - `size` *number* &rarr;  The size of the disk.
+
+    - `type` *string* &rarr;  The type of the disk.
+
+
+- `name` *string* &rarr;  The name of the server.
+
+- `os_type` *string* &rarr;  Server Operation System type.
+
+- `power_state` *string* &rarr;  Server power state.
+
+- `raid_type` *string* &rarr;  Server raid type.
+
+- `ram_megabytes` *number* &rarr;  Server memory size in megabytes.
+
+- `status` *string* &rarr;  Server status.
+
+- `tags` *string* &rarr;  Server tags.
+
+- `target_boot_order`  *list* &rarr;  Current server boot order.
+    - `boot_device_type` *string* &rarr;  The boot device type.
+
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,8 @@ provider "vkcs" {
 - `endpoint_overrides` optional &rarr;  Custom endpoints for corresponding APIs. If not specified, endpoints provided by the catalog will be used.
     - `backup` optional *string* &rarr;  Backup API custom endpoint.
 
+    - `baremetal` optional *string* &rarr;  Bare Metal API custom endpoint.
+
     - `block_storage` optional *string* &rarr;  Block Storage API custom endpoint.
 
     - `cdn` optional *string* &rarr;  CDN API custom endpoint.

--- a/docs/resources/baremetal_flavor_display_name.md
+++ b/docs/resources/baremetal_flavor_display_name.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Baremetal"
+layout: "vkcs"
+page_title: "vkcs: vkcs_baremetal_flavor_display_name"
+description: |-
+  Manages the project-specific display name of an existing VKCS bare metal flavor.
+---
+
+# vkcs_baremetal_flavor_display_name
+
+Manages the project-specific display name of an existing VKCS bare metal flavor. The flavor itself is not created or deleted.
+
+## Example Usage
+
+```terraform
+data "vkcs_baremetal_flavor" "selected" {
+  name = "BM_CX301_N_BOND"
+}
+
+# Get the current project-specific display name.
+output "display_name_before" {
+  value = data.vkcs_baremetal_flavor.selected.display_name
+}
+
+# Write a project-specific display name.
+resource "vkcs_baremetal_flavor_display_name" "main" {
+  id           = data.vkcs_baremetal_flavor.selected.id
+  display_name = "Terraform managed bare metal flavor"
+}
+
+# Rewrite the display name by changing the value above and running:
+# terraform apply
+
+output "display_name" {
+  value = vkcs_baremetal_flavor_display_name.main.display_name
+}
+
+# Reset the display name by running:
+# terraform destroy
+# Destroying this resource clears the project-specific display name.
+```
+
+## Argument Reference
+- `display_name` **required** *string* &rarr;  The project-specific display name of the flavor.
+
+- `id` **required** *string* &rarr;  The UUID of the existing flavor.
+
+
+## Attributes Reference
+No additional attributes are exported.
+
+
+Destroying the resource clears the project-specific display name. The flavor is not deleted.
+
+## Import
+
+An existing flavor can be imported using its ID:
+
+```shell
+terraform import vkcs_baremetal_flavor_display_name.main <flavor-id>
+```

--- a/docs/resources/baremetal_server.md
+++ b/docs/resources/baremetal_server.md
@@ -1,0 +1,195 @@
+---
+subcategory: "Baremetal"
+layout: "vkcs"
+page_title: "vkcs: vkcs_baremetal_server"
+description: |-
+  Manages a bare metal server resource within VKCS.
+---
+
+# vkcs_baremetal_server
+
+
+
+## Example Usage
+### Basic Server
+```terraform
+resource "vkcs_baremetal_server" "server" {
+  name              = "tf-server-57b4d7f1"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  user_data = <<EOF
+    #cloud-config
+    package_upgrade: true
+    packages:
+      - nginx
+    runcmd:
+      - systemctl start nginx
+  EOF
+
+  nic {
+    name = "nic0"
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+  }
+
+  nic {
+    name = "nic1"
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}
+```
+
+### Server with bonded interfaces
+```terraform
+resource "vkcs_baremetal_server" "server_bond" {
+  name              = "server-bond"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  bond {
+    name            = "bond0"
+    interface_names = ["nic0", "nic1"]
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+
+    vlan {
+      id         = 100
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}
+```
+
+```terraform
+resource "vkcs_baremetal_server" "server_bond" {
+  name              = "server-bond"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  bond {
+    name            = "bond0"
+    interface_names = ["nic0"]
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+  }
+
+  bond {
+    name            = "bond1"
+    interface_names = ["nic1"]
+
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}
+```
+
+### Server with tagged VLAN interfaces
+```terraform
+resource "vkcs_baremetal_server" "server_vlan" {
+  name              = "server-vlan"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  nic {
+    name = "nic0"
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+
+    vlan {
+      id         = 100
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}
+```
+
+## Argument Reference
+- `flavor_id` **required** *string* &rarr;  Server flavor to rent.
+
+- `key_pair` **required** *string* &rarr;  The name of a key pair to put on the server. The key pair must already be created and associated with the tenant's account. Changing this creates a new server.
+
+- `name` **required** *string* &rarr;  Name of the bare metal server.
+
+- `availability_zone` optional *string* &rarr;  Availability zone. If not specified, we will chose the availability zone for you.
+
+- `bond` optional &rarr;  Link aggregation interfaces (bonds).
+    - `interface_names` **required** *string* &rarr;  List of interface names participating in the bond.
+
+    - `name` **required** *string* &rarr;  Bond interface name (e.g. bond0).
+
+    - `vlan` optional &rarr;  VLAN configuration applied to the bond.
+        - `id` optional *number* &rarr;  Number of the VLAN.
+
+        - `native` optional *boolean* &rarr;  Whether the VLAN is native.
+
+        - `network_id` optional *string* &rarr;  ID of the network.
+
+        - `subnet_id` optional *string* &rarr;  ID of the subnet.
+
+- `nic` optional &rarr;  Physical network interfaces.
+    - `name` **required** *string* &rarr;  Interface name (e.g. nic0, eno1). Acts as unique identifier.
+
+    - `vlan` optional &rarr;  VLAN configuration. Allowed only if interface is not part of a bond.
+        - `id` optional *number* &rarr;  Number of the VLAN.
+
+        - `native` optional *boolean* &rarr;  Whether the VLAN is native.
+
+        - `network_id` optional *string* &rarr;  ID of the network.
+
+        - `subnet_id` optional *string* &rarr;  ID of the subnet.
+
+- `os_id` optional *string* &rarr;  Set os id.
+
+- `raid_type` optional *string* &rarr;  Parameter to determine should RAID be used during image flashing.
+
+- `region` optional *string* &rarr;  The region to fetch the bare metal server from, defaults to the provider's region.
+
+- `user_data` optional *string* &rarr;  Provide the cloud-init user-data payload.
+
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+- `id` *string* &rarr;  ID of the bare metal server.
+
+
+
+## Import
+
+A bare metal server can be imported using the `id`, e.g.
+```shell
+terraform import vkcs_baremetal_server.server 57b4d7f1-3acc-4843-b811-51df18badd9f
+```

--- a/examples/baremetal/flavor/base-datasource.tf
+++ b/examples/baremetal/flavor/base-datasource.tf
@@ -1,0 +1,3 @@
+data "vkcs_baremetal_flavor" "minimal" {
+  name = "BM_CX301_N_BOND"
+}

--- a/examples/baremetal/flavor/main-datasource.tf
+++ b/examples/baremetal/flavor/main-datasource.tf
@@ -1,0 +1,21 @@
+data "vkcs_baremetal_flavor" "main" {
+  name              = "BM_CX301_N_BOND"
+  cpu_model         = "Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz"
+  cpu_cores         = 32
+  ram_size          = 128
+  ssd_size          = 900
+  hdd_size          = 16000
+  bond_vlan_capable = true
+}
+
+output "flavor_output" {
+  value = {
+    id                = data.vkcs_baremetal_flavor.main.id
+    name              = data.vkcs_baremetal_flavor.main.name
+    cpu_cores         = data.vkcs_baremetal_flavor.main.cpu_cores
+    ram_size          = data.vkcs_baremetal_flavor.main.ram_size
+    ssd_size          = data.vkcs_baremetal_flavor.main.ssd_size
+    hdd_size          = data.vkcs_baremetal_flavor.main.hdd_size
+    bond_vlan_capable = data.vkcs_baremetal_flavor.main.bond_vlan_capable
+  }
+}

--- a/examples/baremetal/flavor/main-datasource.tf
+++ b/examples/baremetal/flavor/main-datasource.tf
@@ -12,6 +12,7 @@ output "flavor_output" {
   value = {
     id                = data.vkcs_baremetal_flavor.main.id
     name              = data.vkcs_baremetal_flavor.main.name
+    display_name      = data.vkcs_baremetal_flavor.main.display_name
     cpu_cores         = data.vkcs_baremetal_flavor.main.cpu_cores
     ram_size          = data.vkcs_baremetal_flavor.main.ram_size
     ssd_size          = data.vkcs_baremetal_flavor.main.ssd_size

--- a/examples/baremetal/flavor/resource/main.tf
+++ b/examples/baremetal/flavor/resource/main.tf
@@ -1,0 +1,25 @@
+data "vkcs_baremetal_flavor" "selected" {
+  name = "BM_CX301_N_BOND"
+}
+
+# Get the current project-specific display name.
+output "display_name_before" {
+  value = data.vkcs_baremetal_flavor.selected.display_name
+}
+
+# Write a project-specific display name.
+resource "vkcs_baremetal_flavor_display_name" "main" {
+  id           = data.vkcs_baremetal_flavor.selected.id
+  display_name = "Terraform managed bare metal flavor"
+}
+
+# Rewrite the display name by changing the value above and running:
+# terraform apply
+
+output "display_name" {
+  value = vkcs_baremetal_flavor_display_name.main.display_name
+}
+
+# Reset the display name by running:
+# terraform destroy
+# Destroying this resource clears the project-specific display name.

--- a/examples/baremetal/flavors/main-datasource.tf
+++ b/examples/baremetal/flavors/main-datasource.tf
@@ -1,0 +1,7 @@
+data "vkcs_baremetal_flavors" "main" {}
+
+output "flavors_output" {
+  value = {
+    flavors = data.vkcs_baremetal_flavors.main
+  }
+}

--- a/examples/baremetal/os/main-datasource.tf
+++ b/examples/baremetal/os/main-datasource.tf
@@ -1,0 +1,14 @@
+data "vkcs_baremetal_os" "ubuntu" {
+  name      = "ubuntu"
+  version   = "24.04"
+  raid_type = "RAID1"
+}
+
+output "flavor_output" {
+  value = {
+    id        = data.vkcs_baremetal_os.ubuntu.id
+    name      = data.vkcs_baremetal_os.ubuntu.name
+    version   = data.vkcs_baremetal_os.ubuntu.version
+    raid_type = data.vkcs_baremetal_os.ubuntu.raid_type
+  }
+}

--- a/examples/baremetal/oses/main-datasource.tf
+++ b/examples/baremetal/oses/main-datasource.tf
@@ -1,0 +1,7 @@
+data "vkcs_baremetal_oses" "main" {}
+
+output "oses_output" {
+  value = {
+    oses = data.vkcs_baremetal_oses.main
+  }
+}

--- a/examples/baremetal/server/basic/base-flavor.tf
+++ b/examples/baremetal/server/basic/base-flavor.tf
@@ -1,0 +1,1 @@
+../../flavor/base-datasource.tf

--- a/examples/baremetal/server/basic/base-keypair.tf
+++ b/examples/baremetal/server/basic/base-keypair.tf
@@ -1,0 +1,1 @@
+../../../compute/keypair/main.tf

--- a/examples/baremetal/server/basic/base-networking.tf
+++ b/examples/baremetal/server/basic/base-networking.tf
@@ -1,0 +1,1 @@
+../../../networking/main.tf

--- a/examples/baremetal/server/basic/base-os.tf
+++ b/examples/baremetal/server/basic/base-os.tf
@@ -1,0 +1,1 @@
+../../os/main-datasource.tf

--- a/examples/baremetal/server/basic/main-datasource.tf
+++ b/examples/baremetal/server/basic/main-datasource.tf
@@ -1,0 +1,55 @@
+data "vkcs_baremetal_server" "server" {
+  id = vkcs_baremetal_server.server.id
+}
+
+output "server_output" {
+  value = {
+    id                = data.vkcs_baremetal_server.server.id
+    name              = data.vkcs_baremetal_server.server.name
+    region            = data.vkcs_baremetal_server.server.region
+    availability_zone = data.vkcs_baremetal_server.server.availability_zone
+
+    cpu_cores = data.vkcs_baremetal_server.server.cpu_cores
+    cpu_types = data.vkcs_baremetal_server.server.cpu_types
+
+    is_locked = data.vkcs_baremetal_server.server.is_locked
+
+    local_disk_sizes = data.vkcs_baremetal_server.server.local_disk_sizes
+    ram_megabytes    = data.vkcs_baremetal_server.server.ram_megabytes
+
+    power_state = data.vkcs_baremetal_server.server.power_state
+    status      = data.vkcs_baremetal_server.server.status
+
+    tags = data.vkcs_baremetal_server.server.tags
+
+    image_id   = data.vkcs_baremetal_server.server.image_id
+    image_name = data.vkcs_baremetal_server.server.image_name
+    os_type    = data.vkcs_baremetal_server.server.os_type
+
+    raid_type = data.vkcs_baremetal_server.server.raid_type
+    flavor_id = data.vkcs_baremetal_server.server.flavor_id
+
+    target_boot_order = data.vkcs_baremetal_server.server.target_boot_order
+
+    local_disks_info = data.vkcs_baremetal_server.server.local_disks_info
+  }
+}
+
+output "boot_devices" {
+  value = [
+    for b in data.vkcs_baremetal_server.server.target_boot_order :
+    b.boot_device_type
+  ]
+}
+
+output "disks" {
+  value = [
+    for d in data.vkcs_baremetal_server.server.local_disks_info : {
+      path  = d.path
+      size  = d.size
+      type  = d.type
+      model = d.model
+    }
+  ]
+}
+

--- a/examples/baremetal/server/basic/main.tf
+++ b/examples/baremetal/server/basic/main.tf
@@ -1,0 +1,35 @@
+resource "vkcs_baremetal_server" "server" {
+  name              = "tf-server-57b4d7f1"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  user_data = <<EOF
+    #cloud-config
+    package_upgrade: true
+    packages:
+      - nginx
+    runcmd:
+      - systemctl start nginx
+  EOF
+
+  nic {
+    name = "nic0"
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+  }
+
+  nic {
+    name = "nic1"
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}

--- a/examples/baremetal/server/bond/base-flavor.tf
+++ b/examples/baremetal/server/bond/base-flavor.tf
@@ -1,0 +1,1 @@
+../../flavor/base-datasource.tf

--- a/examples/baremetal/server/bond/base-keypair.tf
+++ b/examples/baremetal/server/bond/base-keypair.tf
@@ -1,0 +1,1 @@
+../../../compute/keypair/main.tf

--- a/examples/baremetal/server/bond/base-networking.tf
+++ b/examples/baremetal/server/bond/base-networking.tf
@@ -1,0 +1,1 @@
+../../../networking/main.tf

--- a/examples/baremetal/server/bond/base-os.tf
+++ b/examples/baremetal/server/bond/base-os.tf
@@ -1,0 +1,1 @@
+../../os/main-datasource.tf

--- a/examples/baremetal/server/bond/main.tf
+++ b/examples/baremetal/server/bond/main.tf
@@ -1,0 +1,26 @@
+resource "vkcs_baremetal_server" "server_bond" {
+  name              = "server-bond"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  bond {
+    name            = "bond0"
+    interface_names = ["nic0", "nic1"]
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+
+    vlan {
+      id         = 100
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}
+
+

--- a/examples/baremetal/server/bonds/base-flavor.tf
+++ b/examples/baremetal/server/bonds/base-flavor.tf
@@ -1,0 +1,1 @@
+../../flavor/base-datasource.tf

--- a/examples/baremetal/server/bonds/base-keypair.tf
+++ b/examples/baremetal/server/bonds/base-keypair.tf
@@ -1,0 +1,1 @@
+../../../compute/keypair/main.tf

--- a/examples/baremetal/server/bonds/base-networking.tf
+++ b/examples/baremetal/server/bonds/base-networking.tf
@@ -1,0 +1,1 @@
+../../../networking/main.tf

--- a/examples/baremetal/server/bonds/base-os.tf
+++ b/examples/baremetal/server/bonds/base-os.tf
@@ -1,0 +1,1 @@
+../../os/main-datasource.tf

--- a/examples/baremetal/server/bonds/main.tf
+++ b/examples/baremetal/server/bonds/main.tf
@@ -1,0 +1,31 @@
+resource "vkcs_baremetal_server" "server_bond" {
+  name              = "server-bond"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  bond {
+    name            = "bond0"
+    interface_names = ["nic0"]
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+  }
+
+  bond {
+    name            = "bond1"
+    interface_names = ["nic1"]
+
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}
+
+

--- a/examples/baremetal/server/vlan/base-flavor.tf
+++ b/examples/baremetal/server/vlan/base-flavor.tf
@@ -1,0 +1,1 @@
+../../flavor/base-datasource.tf

--- a/examples/baremetal/server/vlan/base-keypair.tf
+++ b/examples/baremetal/server/vlan/base-keypair.tf
@@ -1,0 +1,1 @@
+../../../compute/keypair/main.tf

--- a/examples/baremetal/server/vlan/base-networking.tf
+++ b/examples/baremetal/server/vlan/base-networking.tf
@@ -1,0 +1,1 @@
+../../../networking/main.tf

--- a/examples/baremetal/server/vlan/base-os.tf
+++ b/examples/baremetal/server/vlan/base-os.tf
@@ -1,0 +1,1 @@
+../../os/main-datasource.tf

--- a/examples/baremetal/server/vlan/main.tf
+++ b/examples/baremetal/server/vlan/main.tf
@@ -1,0 +1,25 @@
+resource "vkcs_baremetal_server" "server_vlan" {
+  name              = "server-vlan"
+  availability_zone = "GZ1"
+  flavor_id         = data.vkcs_baremetal_flavor.minimal.id
+  os_id             = data.vkcs_baremetal_os.ubuntu.id
+  key_pair          = vkcs_compute_keypair.generated_key.name
+  raid_type         = "RAID1"
+
+  nic {
+    name = "nic0"
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.app.id
+      subnet_id  = vkcs_networking_subnet.app.id
+    }
+
+    vlan {
+      id         = 100
+      network_id = vkcs_networking_network.db.id
+      subnet_id  = vkcs_networking_subnet.db.id
+    }
+  }
+}
+
+

--- a/templates/baremetal/data-sources/vkcs_baremetal_flavor.md.tmpl
+++ b/templates/baremetal/data-sources/vkcs_baremetal_flavor.md.tmpl
@@ -1,0 +1,17 @@
+---
+subcategory: "{{.SubCategory}}"
+layout: "vkcs"
+page_title: "vkcs: {{.Name}}"
+description: |-
+  Get information on a VKCS bare metal flavor.
+---
+
+# {{.Name}}
+
+{{ .Description }}
+
+## Example Usage
+
+{{tffile "examples/baremetal/flavor/main-datasource.tf"}}
+
+{{ .SchemaMarkdown }}

--- a/templates/baremetal/data-sources/vkcs_baremetal_flavors.md.tmpl
+++ b/templates/baremetal/data-sources/vkcs_baremetal_flavors.md.tmpl
@@ -1,0 +1,17 @@
+---
+subcategory: "{{.SubCategory}}"
+layout: "vkcs"
+page_title: "vkcs: {{.Name}}"
+description: |-
+  Get information on VKCS bare metal flavors.
+---
+
+# {{.Name}}
+
+{{ .Description }}
+
+## Example Usage
+
+{{tffile "examples/baremetal/flavors/main-datasource.tf"}}
+
+{{ .SchemaMarkdown }}

--- a/templates/baremetal/data-sources/vkcs_baremetal_os.md.tmpl
+++ b/templates/baremetal/data-sources/vkcs_baremetal_os.md.tmpl
@@ -1,0 +1,17 @@
+---
+subcategory: "{{.SubCategory}}"
+layout: "vkcs"
+page_title: "vkcs: {{.Name}}"
+description: |-
+  Get information on a VKCS bare metal operating system.
+---
+
+# {{.Name}}
+
+{{ .Description }}
+
+## Example Usage
+
+{{tffile "examples/baremetal/os/main-datasource.tf"}}
+
+{{ .SchemaMarkdown }}

--- a/templates/baremetal/data-sources/vkcs_baremetal_oses.md.tmpl
+++ b/templates/baremetal/data-sources/vkcs_baremetal_oses.md.tmpl
@@ -1,0 +1,17 @@
+---
+subcategory: "{{.SubCategory}}"
+layout: "vkcs"
+page_title: "vkcs: {{.Name}}"
+description: |-
+  Get information on VKCS bare metal operating systems.
+---
+
+# {{.Name}}
+
+{{ .Description }}
+
+## Example Usage
+
+{{tffile "examples/baremetal/oses/main-datasource.tf"}}
+
+{{ .SchemaMarkdown }}

--- a/templates/baremetal/data-sources/vkcs_baremetal_server.md.tmpl
+++ b/templates/baremetal/data-sources/vkcs_baremetal_server.md.tmpl
@@ -1,0 +1,17 @@
+---
+subcategory: "{{.SubCategory}}"
+layout: "vkcs"
+page_title: "vkcs: {{.Name}}"
+description: |-
+  Get information on a VKCS bare metal server.
+---
+
+# {{.Name}}
+
+{{ .Description }}
+
+## Example Usage
+
+{{tffile "examples/baremetal/server/basic/main-datasource.tf"}}
+
+{{ .SchemaMarkdown }}

--- a/templates/baremetal/resources/vkcs_baremetal_flavor_display_name.md.tmpl
+++ b/templates/baremetal/resources/vkcs_baremetal_flavor_display_name.md.tmpl
@@ -1,0 +1,27 @@
+---
+subcategory: "{{.SubCategory}}"
+layout: "vkcs"
+page_title: "vkcs: {{.Name}}"
+description: |-
+  Manages the project-specific display name of an existing VKCS bare metal flavor.
+---
+
+# {{.Name}}
+
+{{ .Description }} The flavor itself is not created or deleted.
+
+## Example Usage
+
+{{tffile "examples/baremetal/flavor/resource/main.tf"}}
+
+{{ .SchemaMarkdown }}
+
+Destroying the resource clears the project-specific display name. The flavor is not deleted.
+
+## Import
+
+An existing flavor can be imported using its ID:
+
+```shell
+terraform import vkcs_baremetal_flavor_display_name.main <flavor-id>
+```

--- a/templates/baremetal/resources/vkcs_baremetal_server.md.tmpl
+++ b/templates/baremetal/resources/vkcs_baremetal_server.md.tmpl
@@ -1,0 +1,30 @@
+---
+subcategory: "{{.SubCategory}}"
+layout: "vkcs"
+page_title: "vkcs: {{.Name}}"
+description: |-
+  Manages a bare metal server resource within VKCS.
+---
+
+# {{.Name}}
+
+{{ .Description }}
+
+## Example Usage
+### Basic Server
+{{tffile "examples/baremetal/server/basic/main.tf"}}
+
+### Server with bonded interfaces
+{{tffile "examples/baremetal/server/bond/main.tf"}}
+
+{{tffile "examples/baremetal/server/bonds/main.tf"}}
+
+### Server with tagged VLAN interfaces
+{{tffile "examples/baremetal/server/vlan/main.tf"}}
+
+{{ .SchemaMarkdown }}
+
+## Import
+
+A bare metal server can be imported using the `id`, e.g.
+{{codefile "shell" "templates/baremetal/resources/vkcs_baremetal_server/import.sh"}}

--- a/templates/baremetal/resources/vkcs_baremetal_server/import.sh
+++ b/templates/baremetal/resources/vkcs_baremetal_server/import.sh
@@ -1,0 +1,1 @@
+terraform import vkcs_baremetal_server.server 57b4d7f1-3acc-4843-b811-51df18badd9f

--- a/vkcs/baremetal/data_source_flavor.go
+++ b/vkcs/baremetal/data_source_flavor.go
@@ -1,0 +1,219 @@
+package baremetal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/flavors"
+)
+
+var _ datasource.DataSource = &FlavorDataSource{}
+var _ datasource.DataSourceWithConfigure = &FlavorDataSource{}
+
+func NewFlavorDataSource() datasource.DataSource {
+	return &FlavorDataSource{}
+}
+
+type FlavorDataSource struct {
+	config clients.Config
+}
+
+type FlavorDataSourceModel struct {
+	ID              types.String `tfsdk:"id"`
+	Region          types.String `tfsdk:"region"`
+	Name            types.String `tfsdk:"name"`
+	CpuModel        types.String `tfsdk:"cpu_model"`
+	CpuCores        types.Int64  `tfsdk:"cpu_cores"`
+	RamSize         types.Int64  `tfsdk:"ram_size"`
+	SsdSize         types.Int64  `tfsdk:"ssd_size"`
+	HddSize         types.Int64  `tfsdk:"hdd_size"`
+	BondVlanCapable types.Bool   `tfsdk:"bond_vlan_capable"`
+}
+
+func (d *FlavorDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "vkcs_baremetal_flavor"
+}
+
+func (d *FlavorDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: "The UUID of the flavor.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("name"),
+						path.MatchRoot("cpu_model"),
+						path.MatchRoot("cpu_cores"),
+						path.MatchRoot("ram_size"),
+						path.MatchRoot("ssd_size"),
+						path.MatchRoot("hdd_size"),
+						path.MatchRoot("bond_vlan_capable"),
+					}...),
+				},
+			},
+			"name": schema.StringAttribute{
+				Optional:    true,
+				Description: "The name of the flavor.",
+			},
+			"region": schema.StringAttribute{
+				Optional:    true,
+				Description: "The region to fetch the bare metal flavor from, defaults to the provider's region.",
+			},
+			"cpu_model": schema.StringAttribute{
+				Optional:    true,
+				Description: "The CPU model.",
+			},
+			"cpu_cores": schema.Int64Attribute{
+				Optional:    true,
+				Description: "CPU core count including hyper-threading.",
+			},
+			"ram_size": schema.Int64Attribute{
+				Optional:    true,
+				Description: "RAM in gigabytes.",
+			},
+			"ssd_size": schema.Int64Attribute{
+				Optional:    true,
+				Description: "SSD size in gigabytes.",
+			},
+			"hdd_size": schema.Int64Attribute{
+				Optional:    true,
+				Description: "HDD size in gigabytes.",
+			},
+			"bond_vlan_capable": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Bond and VLAN capable.",
+			},
+		},
+		Description: "Use this data source to get information about a VKCS Baremetal Flavor.",
+	}
+}
+
+func (d *FlavorDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.config = req.ProviderData.(clients.Config)
+}
+
+func (d *FlavorDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data FlavorDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := data.Region.ValueString()
+	if region == "" {
+		region = d.config.GetRegion()
+	}
+
+	client, err := d.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS Baremetal API client", err.Error())
+		return
+	}
+
+	flavor, err := getFlavor(client, data)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting flavor", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(flavor.FlavorId)
+	data.Region = types.StringValue(region)
+	data.Name = types.StringValue(flavor.FlavorName)
+	data.CpuModel = types.StringValue(flavor.CpuModel)
+	data.CpuCores = types.Int64Value(flavor.CpuCores)
+	data.RamSize = types.Int64Value(flavor.RamGb)
+	for _, disk := range flavor.Disks {
+		if disk.Type == flavors.DiskTypeSSD {
+			data.SsdSize = types.Int64Value(disk.Size)
+		}
+		if disk.Type == flavors.DiskTypeHDD {
+			data.HddSize = types.Int64Value(disk.Size)
+		}
+	}
+	data.BondVlanCapable = types.BoolValue(flavor.BondAndVlanCapable)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func getFlavor(client *gophercloud.ServiceClient, data FlavorDataSourceModel) (*flavors.Flavor, error) {
+	if !data.ID.IsNull() && !data.ID.IsUnknown() {
+		return flavors.Get(client, data.ID.ValueString()).Extract()
+	}
+
+	flavorPages, err := flavors.List(client, &flavors.ListOpts{
+		CpuModel:    data.CpuModel.ValueStringPointer(),
+		CpuCoresMin: data.CpuCores.ValueInt64Pointer(),
+		CpuCoresMax: data.CpuCores.ValueInt64Pointer(),
+		RamSizeMin:  data.RamSize.ValueInt64Pointer(),
+		RamSizeMax:  data.RamSize.ValueInt64Pointer(),
+		SsdSizeMin:  data.SsdSize.ValueInt64Pointer(),
+		SsdSizeMax:  data.SsdSize.ValueInt64Pointer(),
+		HddSizeMin:  data.HddSize.ValueInt64Pointer(),
+		HddSizeMax:  data.HddSize.ValueInt64Pointer(),
+	}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	fvs, err := flavors.ExtractFlavors(flavorPages)
+	if err != nil {
+		return nil, err
+	}
+
+	filterFvs := filterFlavors(fvs, data)
+
+	if len(filterFvs) == 0 {
+		return nil, fmt.Errorf("no flavors found by params")
+	}
+
+	if len(filterFvs) > 1 {
+		return nil, fmt.Errorf("multiple flavors found by params")
+	}
+
+	return &filterFvs[0], nil
+}
+
+func filterFlavors(items []flavors.Flavor, data FlavorDataSourceModel) (r []flavors.Flavor) {
+	for _, item := range items {
+		if flavorMatches(data, item) {
+			r = append(r, item)
+		}
+	}
+
+	return
+}
+
+func flavorMatches(data FlavorDataSourceModel, item flavors.Flavor) bool {
+	if !data.Name.IsNull() && !data.Name.IsUnknown() {
+		if item.FlavorName != data.Name.ValueString() {
+			return false
+		}
+	}
+
+	if !data.BondVlanCapable.IsNull() && !data.BondVlanCapable.IsUnknown() {
+		if item.BondAndVlanCapable != data.BondVlanCapable.ValueBool() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vkcs/baremetal/data_source_flavor.go
+++ b/vkcs/baremetal/data_source_flavor.go
@@ -30,6 +30,7 @@ type FlavorDataSourceModel struct {
 	ID              types.String `tfsdk:"id"`
 	Region          types.String `tfsdk:"region"`
 	Name            types.String `tfsdk:"name"`
+	DisplayName     types.String `tfsdk:"display_name"`
 	CpuModel        types.String `tfsdk:"cpu_model"`
 	CpuCores        types.Int64  `tfsdk:"cpu_cores"`
 	RamSize         types.Int64  `tfsdk:"ram_size"`
@@ -62,8 +63,13 @@ func (d *FlavorDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				},
 			},
 			"name": schema.StringAttribute{
+				Computed:    true,
 				Optional:    true,
 				Description: "The name of the flavor.",
+			},
+			"display_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "The project-specific display name of the flavor.",
 			},
 			"region": schema.StringAttribute{
 				Optional:    true,
@@ -134,6 +140,7 @@ func (d *FlavorDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	data.ID = types.StringValue(flavor.FlavorId)
 	data.Region = types.StringValue(region)
 	data.Name = types.StringValue(flavor.FlavorName)
+	data.DisplayName = types.StringPointerValue(flavor.DisplayName)
 	data.CpuModel = types.StringValue(flavor.CpuModel)
 	data.CpuCores = types.Int64Value(flavor.CpuCores)
 	data.RamSize = types.Int64Value(flavor.RamGb)

--- a/vkcs/baremetal/data_source_flavor_test.go
+++ b/vkcs/baremetal/data_source_flavor_test.go
@@ -1,0 +1,32 @@
+package baremetal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
+)
+
+func TestAccBareMetalFlavorDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.AccTestRenderConfig(testAccFlavorDataSourceBasic),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vkcs_baremetal_flavor.basic", "cpu_model"),
+					resource.TestCheckResourceAttrSet("data.vkcs_baremetal_flavor.basic", "cpu_cores"),
+					resource.TestCheckResourceAttrSet("data.vkcs_baremetal_flavor.basic", "ram_size"),
+					resource.TestCheckResourceAttrSet("data.vkcs_baremetal_flavor.basic", "bond_vlan_capable"),
+				),
+			},
+		},
+	})
+}
+
+const testAccFlavorDataSourceBasic = `
+data "vkcs_baremetal_flavor" "basic" {
+  name = "test_flavor2"
+}
+`

--- a/vkcs/baremetal/data_source_flavors.go
+++ b/vkcs/baremetal/data_source_flavors.go
@@ -1,0 +1,167 @@
+package baremetal
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/flavors"
+)
+
+var (
+	_ datasource.DataSource              = &FlavorsDataSource{}
+	_ datasource.DataSourceWithConfigure = &FlavorsDataSource{}
+)
+
+func NewFlavorsDataSource() datasource.DataSource {
+	return &FlavorsDataSource{}
+}
+
+type FlavorsDataSource struct {
+	config clients.Config
+}
+
+type FlavorsDataSourceModel struct {
+	Region  types.String  `tfsdk:"region"`
+	Flavors []FlavorModel `tfsdk:"flavors"`
+}
+
+type FlavorModel struct {
+	Name            types.String `tfsdk:"name"`
+	CpuModel        types.String `tfsdk:"cpu_model"`
+	CpuCores        types.Int64  `tfsdk:"cpu_cores"`
+	RamSize         types.Int64  `tfsdk:"ram_size"`
+	SsdSize         types.Int64  `tfsdk:"ssd_size"`
+	HddSize         types.Int64  `tfsdk:"hdd_size"`
+	BondVlanCapable types.Bool   `tfsdk:"bond_vlan_capable"`
+}
+
+func (d *FlavorsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "vkcs_baremetal_flavors"
+}
+
+func (d *FlavorsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"region": schema.StringAttribute{
+				Optional:    true,
+				Description: "The region to fetch the bare metal flavor from, defaults to the provider's region.",
+			},
+			"flavors": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "The name of the flavor.",
+						},
+						"cpu_model": schema.StringAttribute{
+							Computed:    true,
+							Description: "The CPU model.",
+						},
+						"cpu_cores": schema.Int64Attribute{
+							Computed:    true,
+							Description: "CPU core count including hyper-threading.",
+						},
+						"ram_size": schema.Int64Attribute{
+							Computed:    true,
+							Description: "RAM in gigabytes.",
+						},
+						"ssd_size": schema.Int64Attribute{
+							Computed:    true,
+							Description: "SSD size in gigabytes.",
+						},
+						"hdd_size": schema.Int64Attribute{
+							Computed:    true,
+							Description: "HDD size in gigabytes.",
+						},
+						"bond_vlan_capable": schema.BoolAttribute{
+							Computed:    true,
+							Description: "Bond and VLAN capable.",
+						},
+					},
+				},
+				Description: "Available Baremetal Flavors.",
+			},
+		},
+		Description: "Use this data source to get a list of available VKCS Baremetal Flavors.",
+	}
+}
+
+func (d *FlavorsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.config = req.ProviderData.(clients.Config)
+}
+
+func (d *FlavorsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data FlavorsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := data.Region.ValueString()
+	if region == "" {
+		region = d.config.GetRegion()
+	}
+
+	client, err := d.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS Baremetal API client", err.Error())
+		return
+	}
+
+	tflog.Debug(ctx, "Calling baremetal API to get list of flavors")
+
+	flavorPages, err := flavors.List(client, nil).AllPages()
+	if err != nil {
+		resp.Diagnostics.AddError("Error calling VKCS Baremetal API", err.Error())
+		return
+	}
+
+	fvs, err := flavors.ExtractFlavors(flavorPages)
+	if err != nil {
+		resp.Diagnostics.AddError("Error extract flavors", err.Error())
+		return
+	}
+
+	data.Region = types.StringValue(region)
+	data.Flavors = flattenFlavors(fvs)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func flattenFlavors(items []flavors.Flavor) (r []FlavorModel) {
+	for _, item := range items {
+		elem := FlavorModel{
+			Name:            types.StringValue(item.FlavorName),
+			CpuModel:        types.StringValue(item.CpuModel),
+			CpuCores:        types.Int64Value(item.CpuCores),
+			RamSize:         types.Int64Value(item.RamGb),
+			BondVlanCapable: types.BoolValue(item.BondAndVlanCapable),
+		}
+		for _, disk := range item.Disks {
+			if disk.Type == flavors.DiskTypeSSD {
+				elem.SsdSize = types.Int64Value(disk.Size)
+			}
+			if disk.Type == flavors.DiskTypeHDD {
+				elem.HddSize = types.Int64Value(disk.Size)
+			}
+		}
+		r = append(r, elem)
+	}
+
+	sort.SliceStable(r, func(i, j int) bool {
+		return r[i].Name.ValueString() < r[j].Name.ValueString()
+	})
+
+	return
+}

--- a/vkcs/baremetal/data_source_flavors.go
+++ b/vkcs/baremetal/data_source_flavors.go
@@ -32,6 +32,7 @@ type FlavorsDataSourceModel struct {
 
 type FlavorModel struct {
 	Name            types.String `tfsdk:"name"`
+	DisplayName     types.String `tfsdk:"display_name"`
 	CpuModel        types.String `tfsdk:"cpu_model"`
 	CpuCores        types.Int64  `tfsdk:"cpu_cores"`
 	RamSize         types.Int64  `tfsdk:"ram_size"`
@@ -58,6 +59,10 @@ func (d *FlavorsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 						"name": schema.StringAttribute{
 							Computed:    true,
 							Description: "The name of the flavor.",
+						},
+						"display_name": schema.StringAttribute{
+							Computed:    true,
+							Description: "The project-specific display name of the flavor.",
 						},
 						"cpu_model": schema.StringAttribute{
 							Computed:    true,
@@ -143,6 +148,7 @@ func flattenFlavors(items []flavors.Flavor) (r []FlavorModel) {
 	for _, item := range items {
 		elem := FlavorModel{
 			Name:            types.StringValue(item.FlavorName),
+			DisplayName:     types.StringPointerValue(item.DisplayName),
 			CpuModel:        types.StringValue(item.CpuModel),
 			CpuCores:        types.Int64Value(item.CpuCores),
 			RamSize:         types.Int64Value(item.RamGb),

--- a/vkcs/baremetal/data_source_flavors_test.go
+++ b/vkcs/baremetal/data_source_flavors_test.go
@@ -1,0 +1,52 @@
+package baremetal_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
+)
+
+func TestAccBareMetalFlavorsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlavorsDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						resourceName := "data.vkcs_baremetal_flavors.basic"
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("root module has no resource called %s", resourceName)
+						}
+
+						flavors, ok := rs.Primary.Attributes["flavors.#"]
+						if !ok {
+							return fmt.Errorf("flavors attribute is missing")
+						}
+
+						flavorsQuantity, err := strconv.Atoi(flavors)
+						if err != nil {
+							return fmt.Errorf("error parsing flavors (%s) into integer: %s", flavors, err)
+						}
+
+						if flavorsQuantity == 0 {
+							return fmt.Errorf("no flavors found, this is probably a bug")
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+const testAccFlavorsDataSourceBasic = `
+data "vkcs_baremetal_flavors" "basic" {}
+`

--- a/vkcs/baremetal/data_source_os.go
+++ b/vkcs/baremetal/data_source_os.go
@@ -1,0 +1,178 @@
+package baremetal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/images"
+)
+
+var _ datasource.DataSource = &OSDataSource{}
+var _ datasource.DataSourceWithConfigure = &OSDataSource{}
+
+func NewOSDataSource() datasource.DataSource {
+	return &OSDataSource{}
+}
+
+type OSDataSource struct {
+	config clients.Config
+}
+
+type OSDataSourceModel struct {
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+	Region   types.String `tfsdk:"region"`
+	Version  types.String `tfsdk:"version"`
+	RaidType types.String `tfsdk:"raid_type"`
+}
+
+func (d *OSDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "vkcs_baremetal_os"
+}
+
+func (d *OSDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: "The UUID of the OS.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("name"),
+						path.MatchRoot("version"),
+						path.MatchRoot("raid_type"),
+					}...),
+				},
+			},
+			"name": schema.StringAttribute{
+				Optional:    true,
+				Description: "The name of the OS.",
+			},
+			"region": schema.StringAttribute{
+				Optional:    true,
+				Description: "The region to fetch the bare metal OS from, defaults to the provider's region.",
+			},
+			"version": schema.StringAttribute{
+				Optional:    true,
+				Description: "The version of the OS.",
+			},
+			"raid_type": schema.StringAttribute{
+				Optional:    true,
+				Description: "The raid type of the OS.",
+			},
+		},
+		Description: "Use this data source to get information about a VKCS baremetal OS.",
+	}
+}
+
+func (d *OSDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.config = req.ProviderData.(clients.Config)
+}
+
+func (d *OSDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data OSDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := data.Region.ValueString()
+	if region == "" {
+		region = d.config.GetRegion()
+	}
+
+	client, err := d.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	image, err := getImage(client, data)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting image", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(image.ImageId)
+	data.Region = types.StringValue(region)
+	data.Name = types.StringValue(image.OsType)
+	data.Version = types.StringValue(image.OsVersion)
+	data.RaidType = types.StringValue(image.RaidType)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func getImage(client *gophercloud.ServiceClient, data OSDataSourceModel) (*images.Image, error) {
+	if !data.ID.IsNull() && !data.ID.IsUnknown() {
+		return images.Get(client, data.ID.ValueString()).Extract()
+	}
+
+	imagePages, err := images.List(client).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	imgs, err := images.ExtractImages(imagePages)
+	if err != nil {
+		return nil, err
+	}
+
+	filterImgs := filterImages(data, imgs)
+	if len(filterImgs) == 0 {
+		return nil, fmt.Errorf("no images found for OS")
+	}
+
+	if len(filterImgs) > 1 {
+		return nil, fmt.Errorf("multiple images found for OS")
+	}
+
+	return &filterImgs[0], nil
+}
+
+func filterImages(data OSDataSourceModel, items []images.Image) (r []images.Image) {
+	for _, item := range items {
+		if imageMatches(data, item) {
+			r = append(r, item)
+		}
+	}
+
+	return
+}
+
+func imageMatches(data OSDataSourceModel, item images.Image) bool {
+	if !data.Name.IsNull() && !data.Name.IsUnknown() {
+		if !strings.EqualFold(item.OsType, data.Name.ValueString()) {
+			return false
+		}
+	}
+	if !data.Version.IsNull() && !data.Version.IsUnknown() {
+		if !strings.EqualFold(item.OsVersion, data.Version.ValueString()) {
+			return false
+		}
+	}
+	if !data.RaidType.IsNull() && !data.RaidType.IsUnknown() {
+		if !strings.EqualFold(item.RaidType, data.RaidType.ValueString()) {
+			return false
+		}
+	}
+	return true
+}

--- a/vkcs/baremetal/data_source_os_test.go
+++ b/vkcs/baremetal/data_source_os_test.go
@@ -1,0 +1,31 @@
+package baremetal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
+)
+
+func TestAccBareMetalOSDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.AccTestRenderConfig(testAccOSDataSourceBasic),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vkcs_baremetal_os.basic", "id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccOSDataSourceBasic = `
+data "vkcs_baremetal_os" "basic" {
+  name      = "ubuntu"
+  version   = "22.04"
+  raid_type = "no_raid"
+}
+`

--- a/vkcs/baremetal/data_source_oses.go
+++ b/vkcs/baremetal/data_source_oses.go
@@ -1,0 +1,140 @@
+package baremetal
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/images"
+)
+
+var (
+	_ datasource.DataSource              = &OSesDataSource{}
+	_ datasource.DataSourceWithConfigure = &OSesDataSource{}
+)
+
+func NewOSesDataSource() datasource.DataSource {
+	return &OSesDataSource{}
+}
+
+type OSesDataSource struct {
+	config clients.Config
+}
+
+type OSesDataSourceModel struct {
+	Region types.String `tfsdk:"region"`
+	OSes   []OSModel    `tfsdk:"oses"`
+}
+
+type OSModel struct {
+	Name     types.String `tfsdk:"name"`
+	Version  types.String `tfsdk:"version"`
+	RaidType types.String `tfsdk:"raid_type"`
+}
+
+func (d *OSesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "vkcs_baremetal_oses"
+}
+
+func (d *OSesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"region": schema.StringAttribute{
+				Optional:    true,
+				Description: "The region to fetch the bare metal OSes from, defaults to the provider's region.",
+			},
+			"oses": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "The name of the OS.",
+						},
+						"version": schema.StringAttribute{
+							Computed:    true,
+							Description: "The version of the OS.",
+						},
+						"raid_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "The raid type of the OS.",
+						},
+					},
+				},
+				Description: "Available Baremetal OSes.",
+			},
+		},
+		Description: "Use this data source to get a list of available VKCS Baremetal OSes.",
+	}
+}
+
+func (d *OSesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.config = req.ProviderData.(clients.Config)
+}
+
+func (d *OSesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data OSesDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := data.Region.ValueString()
+	if region == "" {
+		region = d.config.GetRegion()
+	}
+
+	client, err := d.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS Baremetal API client", err.Error())
+		return
+	}
+
+	tflog.Debug(ctx, "Calling baremetal API to get list of images")
+
+	imagePages, err := images.List(client).AllPages()
+	if err != nil {
+		resp.Diagnostics.AddError("Error calling VKCS Baremetal API", err.Error())
+		return
+	}
+
+	imgs, err := images.ExtractImages(imagePages)
+	if err != nil {
+		resp.Diagnostics.AddError("Error extract images", err.Error())
+		return
+	}
+
+	data.Region = types.StringValue(region)
+	data.OSes = flattenImages(imgs)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func flattenImages(items []images.Image) (r []OSModel) {
+	for _, item := range items {
+		r = append(r, OSModel{
+			Name:     types.StringValue(item.OsType),
+			Version:  types.StringValue(item.OsVersion),
+			RaidType: types.StringValue(item.RaidType),
+		})
+	}
+
+	sort.SliceStable(r, func(i, j int) bool {
+		if r[i].Name.ValueString() != r[j].Name.ValueString() {
+			return r[i].Name.ValueString() < r[j].Name.ValueString()
+		}
+
+		return r[i].Version.ValueString() < r[j].Version.ValueString()
+	})
+
+	return
+}

--- a/vkcs/baremetal/data_source_oses_test.go
+++ b/vkcs/baremetal/data_source_oses_test.go
@@ -1,0 +1,52 @@
+package baremetal_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
+)
+
+func TestAccBareMetalOSesDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOSesDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						resourceName := "data.vkcs_baremetal_oses.basic"
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("root module has no resource called %s", resourceName)
+						}
+
+						oses, ok := rs.Primary.Attributes["oses.#"]
+						if !ok {
+							return fmt.Errorf("oses attribute is missing")
+						}
+
+						osesQuantity, err := strconv.Atoi(oses)
+						if err != nil {
+							return fmt.Errorf("error parsing oses (%s) into integer: %s", oses, err)
+						}
+
+						if osesQuantity == 0 {
+							return fmt.Errorf("no oses found, this is probably a bug")
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+const testAccOSesDataSourceBasic = `
+data "vkcs_baremetal_oses" "basic" {}
+`

--- a/vkcs/baremetal/data_source_server.go
+++ b/vkcs/baremetal/data_source_server.go
@@ -1,0 +1,281 @@
+package baremetal
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/servers"
+)
+
+var _ datasource.DataSource = &ServerDataSource{}
+var _ datasource.DataSourceWithConfigure = &ServerDataSource{}
+
+func NewServerDataSource() datasource.DataSource {
+	return &ServerDataSource{}
+}
+
+type ServerDataSource struct {
+	config clients.Config
+}
+
+type ServerDataSourceModel struct {
+	ID               types.String           `tfsdk:"id"`
+	Region           types.String           `tfsdk:"region"`
+	Name             types.String           `tfsdk:"name"`
+	AvailabilityZone types.String           `tfsdk:"availability_zone"`
+	CpuCores         types.List             `tfsdk:"cpu_cores"`
+	CpuTypes         types.List             `tfsdk:"cpu_types"`
+	IsLocked         types.Bool             `tfsdk:"is_locked"`
+	LocalDiskSizes   types.List             `tfsdk:"local_disk_sizes"`
+	RamMegabytes     types.Int64            `tfsdk:"ram_megabytes"`
+	PowerState       types.String           `tfsdk:"power_state"`
+	Tags             types.List             `tfsdk:"tags"`
+	ImageID          types.String           `tfsdk:"image_id"`
+	ImageName        types.String           `tfsdk:"image_name"`
+	OsType           types.String           `tfsdk:"os_type"`
+	RaidType         types.String           `tfsdk:"raid_type"`
+	Status           types.String           `tfsdk:"status"`
+	FlavorID         types.String           `tfsdk:"flavor_id"`
+	TargetBootOrder  []TargetBootOrderModel `tfsdk:"target_boot_order"`
+	LocalDisksInfo   []LocalDiskInfoModel   `tfsdk:"local_disks_info"`
+}
+
+type TargetBootOrderModel struct {
+	BootDeviceType types.String `tfsdk:"boot_device_type"`
+}
+
+type LocalDiskInfoModel struct {
+	Path  types.String `tfsdk:"path"`
+	Size  types.Int64  `tfsdk:"size"`
+	Type  types.String `tfsdk:"type"`
+	Model types.String `tfsdk:"model"`
+}
+
+func (s *ServerDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "vkcs_baremetal_server"
+}
+
+func (s *ServerDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required:    true,
+				Description: "The UUID of the bare metal server.",
+			},
+			"name": schema.StringAttribute{
+				Computed:    true,
+				Description: "The name of the server.",
+			},
+			"region": schema.StringAttribute{
+				Optional:    true,
+				Description: "The region to fetch the bare metal server from, defaults to the provider's region.",
+			},
+			"availability_zone": schema.StringAttribute{
+				Computed:    true,
+				Description: "The availability zone of this server.",
+			},
+			"cpu_cores": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.Int64Type,
+				Description: "CPU core count including hyper-threading.",
+			},
+			"cpu_types": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "Server CPU type.",
+			},
+			"is_locked": schema.BoolAttribute{
+				Computed: true,
+				Description: "Shows whether the server is protected." +
+					" The server cannot be deleted while this flag is set.",
+			},
+			"local_disk_sizes": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.Int64Type,
+				Description: "Local disk sizes in gigabytes.",
+			},
+			"ram_megabytes": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Server memory size in megabytes.",
+			},
+			"power_state": schema.StringAttribute{
+				Computed:    true,
+				Description: "Server power state.",
+			},
+			"tags": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "Server tags.",
+			},
+			"image_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The image ID used to create the server.",
+			},
+			"image_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "The image name used to create the server.",
+			},
+			"os_type": schema.StringAttribute{
+				Computed:    true,
+				Description: "Server Operation System type.",
+			},
+			"raid_type": schema.StringAttribute{
+				Computed:    true,
+				Description: "Server raid type.",
+			},
+			"status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Server status.",
+			},
+			"flavor_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Flavor ID of the server.",
+			},
+			"target_boot_order": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Current server boot order.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"boot_device_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "The boot device type.",
+						},
+					},
+				},
+			},
+			"local_disks_info": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Information about server disks.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"path": schema.StringAttribute{
+							Computed:    true,
+							Description: "The path to the disk.",
+						},
+						"size": schema.Int64Attribute{
+							Computed:    true,
+							Description: "The size of the disk.",
+						},
+						"type": schema.StringAttribute{
+							Computed:    true,
+							Description: "The type of the disk.",
+						},
+						"model": schema.StringAttribute{
+							Computed:    true,
+							Description: "The model of the disk.",
+						},
+					},
+				},
+			},
+		},
+		Description: "Use this data source to get information about a VKCS bare metal server.",
+	}
+}
+
+func (s *ServerDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	s.config = req.ProviderData.(clients.Config)
+}
+
+func (s *ServerDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data ServerDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := data.Region.ValueString()
+	if region == "" {
+		region = s.config.GetRegion()
+	}
+
+	client, err := s.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	serverID := data.ID.ValueString()
+	ctx = tflog.SetField(ctx, "server_id", serverID)
+
+	tflog.Debug(ctx, "Calling VKCS baremetal API to retrieve server by id", map[string]interface{}{"id": serverID})
+	server, err := servers.Get(client, serverID).Extract()
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading baremetal server", err.Error())
+		return
+	}
+
+	data.Name = types.StringValue(server.ServerName)
+	data.Region = types.StringValue(region)
+	data.AvailabilityZone = types.StringValue(server.AvailabilityZone)
+	data.TargetBootOrder = flattenTargetBootOrder(server.TargetBootOrder)
+	data.LocalDisksInfo = flattenLocalDiskInfo(server.LocalDisksInfo)
+	data.IsLocked = types.BoolValue(server.IsLocked)
+	data.RamMegabytes = types.Int64Value(server.MemoryMegabytes)
+	data.PowerState = types.StringValue(server.PowerState)
+	data.ImageID = types.StringPointerValue(server.ImageId)
+	data.ImageName = types.StringPointerValue(server.ImageName)
+	data.OsType = types.StringPointerValue(server.OsType)
+	data.RaidType = types.StringPointerValue(server.RaidType)
+	data.Status = types.StringValue(string(server.Status))
+	data.FlavorID = types.StringPointerValue(server.FlavorId)
+
+	var d diag.Diagnostics
+	data.CpuCores, d = types.ListValueFrom(ctx, types.Int64Type, server.CpuCores)
+	resp.Diagnostics.Append(d...)
+	data.CpuTypes, d = types.ListValueFrom(ctx, types.StringType, server.CpuTypes)
+	resp.Diagnostics.Append(d...)
+	data.LocalDiskSizes, d = types.ListValueFrom(ctx, types.Int64Type, server.LocalDiskSizes)
+	resp.Diagnostics.Append(d...)
+	data.Tags, d = types.ListValueFrom(ctx, types.StringType, server.Tags)
+	resp.Diagnostics.Append(d...)
+
+	if d.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func flattenTargetBootOrder(items []*servers.BootOrderListItem) []TargetBootOrderModel {
+	r := make([]TargetBootOrderModel, len(items))
+	for idx, item := range items {
+		r[idx] = TargetBootOrderModel{
+			BootDeviceType: types.StringValue(item.BootDeviceType),
+		}
+	}
+
+	sort.SliceStable(r, func(i, j int) bool {
+		return r[i].BootDeviceType.ValueString() > r[j].BootDeviceType.ValueString()
+	})
+
+	return r
+}
+
+func flattenLocalDiskInfo(info []*servers.LocalDiskInfo) []LocalDiskInfoModel {
+	r := make([]LocalDiskInfoModel, len(info))
+	for idx, item := range info {
+		r[idx] = LocalDiskInfoModel{
+			Path:  types.StringValue(item.Path),
+			Size:  types.Int64Value(item.SizeGb),
+			Type:  types.StringValue(item.Type),
+			Model: types.StringPointerValue(item.Model),
+		}
+	}
+
+	sort.SliceStable(r, func(i, j int) bool {
+		return r[i].Path.ValueString() > r[j].Path.ValueString()
+	})
+
+	return r
+}

--- a/vkcs/baremetal/data_source_server_test.go
+++ b/vkcs/baremetal/data_source_server_test.go
@@ -1,0 +1,39 @@
+package baremetal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
+)
+
+// TestManualAccBareMetalServerDataSource_basic is a manual acceptance test.
+// It cannot be executed in an automated environment because provisioning
+// a vkcs_baremetal_server requires allocation of a real physical server,
+// which is costly, and not suitable for routine test runs. This is too inefficient.
+func TestManualAccBareMetalServerDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.AccTestRenderConfig(testAccServerDataSourceBasic, map[string]string{
+					"TestAccBareMetalServerResourceBasic": acctest.AccTestRenderConfig(testAccServerResourceBasic),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vkcs_baremetal_server.basic", "availability_zone", "ME1"),
+					resource.TestCheckResourceAttr("data.vkcs_baremetal_server.basic", "image_source", "PUBLIC"),
+					resource.TestCheckResourceAttr("data.vkcs_baremetal_server.basic", "raid_type", "RAID1"),
+				),
+			},
+		},
+	})
+}
+
+const testAccServerDataSourceBasic = `
+{{.TestAccBareMetalServerResourceBasic}}
+
+data "vkcs_baremetal_server" "basic" {
+   id = vkcs_baremetal_server.basic.id
+}
+`

--- a/vkcs/baremetal/resource_flavor_display_name.go
+++ b/vkcs/baremetal/resource_flavor_display_name.go
@@ -1,0 +1,185 @@
+package baremetal
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/flavors"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/errutil"
+)
+
+var (
+	_ resource.Resource                = (*FlavorDisplayNameResource)(nil)
+	_ resource.ResourceWithConfigure   = (*FlavorDisplayNameResource)(nil)
+	_ resource.ResourceWithImportState = (*FlavorDisplayNameResource)(nil)
+)
+
+// NewFlavorDisplayNameResource manages the project-specific display name of an existing bare metal flavor.
+func NewFlavorDisplayNameResource() resource.Resource {
+	return &FlavorDisplayNameResource{}
+}
+
+type FlavorDisplayNameResource struct {
+	config clients.Config
+}
+
+type FlavorDisplayNameResourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	DisplayName types.String `tfsdk:"display_name"`
+}
+
+func (r *FlavorDisplayNameResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "vkcs_baremetal_flavor_display_name"
+}
+
+func (r *FlavorDisplayNameResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The UUID of the existing flavor.",
+			},
+			"display_name": schema.StringAttribute{
+				Required:    true,
+				Description: "The project-specific display name of the flavor.",
+			},
+		},
+		Description: "Manages the project-specific display name of an existing VKCS bare metal flavor.",
+	}
+}
+
+func (r *FlavorDisplayNameResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.config = req.ProviderData.(clients.Config)
+}
+
+func (r *FlavorDisplayNameResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data FlavorDisplayNameResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.config.BareMetalV1Client(r.config.GetRegion())
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	if err := setFlavorDisplayName(client, data.ID.ValueString(), data.DisplayName.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error updating baremetal flavor display name", err.Error())
+		return
+	}
+
+	flavor, err := flavors.Get(client, data.ID.ValueString()).Extract()
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading baremetal flavor after update", err.Error())
+		return
+	}
+
+	setFlavorDisplayNameResourceModel(&data, flavor)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *FlavorDisplayNameResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data FlavorDisplayNameResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.config.BareMetalV1Client(r.config.GetRegion())
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	flavor, err := flavors.Get(client, data.ID.ValueString()).Extract()
+	if errutil.IsNotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading baremetal flavor", err.Error())
+		return
+	}
+
+	setFlavorDisplayNameResourceModel(&data, flavor)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *FlavorDisplayNameResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan FlavorDisplayNameResourceModel
+	var state FlavorDisplayNameResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.config.BareMetalV1Client(r.config.GetRegion())
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	if err := setFlavorDisplayName(client, state.ID.ValueString(), plan.DisplayName.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error updating baremetal flavor display name", err.Error())
+		return
+	}
+
+	flavor, err := flavors.Get(client, state.ID.ValueString()).Extract()
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading baremetal flavor after update", err.Error())
+		return
+	}
+
+	setFlavorDisplayNameResourceModel(&state, flavor)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *FlavorDisplayNameResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data FlavorDisplayNameResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.config.BareMetalV1Client(r.config.GetRegion())
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	if err := setFlavorDisplayName(client, data.ID.ValueString(), ""); errutil.IsNotFound(err) {
+		return
+	} else if err != nil {
+		resp.Diagnostics.AddError("Error clearing baremetal flavor display name", err.Error())
+	}
+}
+
+func (r *FlavorDisplayNameResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func setFlavorDisplayName(client *gophercloud.ServiceClient, flavorID, displayName string) error {
+	return flavors.Update(client, flavorID, flavors.UpdateOpts{DisplayName: &displayName}).ExtractErr()
+}
+
+func setFlavorDisplayNameResourceModel(data *FlavorDisplayNameResourceModel, flavor *flavors.Flavor) {
+	data.ID = types.StringValue(flavor.FlavorId)
+	data.DisplayName = types.StringPointerValue(flavor.DisplayName)
+}

--- a/vkcs/baremetal/resource_flavor_display_name_test.go
+++ b/vkcs/baremetal/resource_flavor_display_name_test.go
@@ -1,0 +1,61 @@
+package baremetal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+)
+
+func TestAccBareMetalFlavorDisplayNameResource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccBareMetalFlavorDisplayNamePreCheck(t) },
+		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlavorDisplayNameResourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vkcs_baremetal_flavor_display_name.basic", "display_name", "TerraformAccTestBasic"),
+				),
+			},
+			{
+				Config: testAccFlavorDisplayNameResourceUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vkcs_baremetal_flavor_display_name.basic", "display_name", "TerraformAccTestUpdated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBareMetalFlavorDisplayNamePreCheck(t *testing.T) {
+	t.Helper()
+
+	opts := clients.ConfigOpts{}
+	if _, err := opts.LoadAndValidate(); err != nil {
+		t.Fatalf("Error loading VKCS configuration for acceptance test: %s", err)
+	}
+}
+
+const testAccFlavorDisplayNameResourceBasic = `
+data "vkcs_baremetal_flavor" "basic" {
+  name = "test_flavor2"
+}
+
+resource "vkcs_baremetal_flavor_display_name" "basic" {
+  id           = data.vkcs_baremetal_flavor.basic.id
+  display_name = "TerraformAccTestBasic"
+}
+`
+
+const testAccFlavorDisplayNameResourceUpdated = `
+data "vkcs_baremetal_flavor" "basic" {
+  name = "test_flavor2"
+}
+
+resource "vkcs_baremetal_flavor_display_name" "basic" {
+  id           = data.vkcs_baremetal_flavor.basic.id
+  display_name = "TerraformAccTestUpdated"
+}
+`

--- a/vkcs/baremetal/resource_server.go
+++ b/vkcs/baremetal/resource_server.go
@@ -1,0 +1,817 @@
+package baremetal
+
+import (
+	"cmp"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/clients"
+	v1 "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/rents"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1/servers"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/errutil"
+)
+
+const (
+	serverDelay         = 10 * time.Second
+	serverMinTimeout    = 10 * time.Second
+	serverCreateTimeout = 30 * time.Minute
+)
+
+const (
+	reprovisionKey = "reprovision"
+)
+
+type reprovision struct {
+	Enabled bool
+}
+
+var (
+	_ resource.Resource                     = &ServerResource{}
+	_ resource.ResourceWithConfigure        = &ServerResource{}
+	_ resource.ResourceWithImportState      = &ServerResource{}
+	_ resource.ResourceWithModifyPlan       = &ServerResource{}
+	_ resource.ResourceWithConfigValidators = &ServerResource{}
+)
+
+func NewServerResource() resource.Resource {
+	return &ServerResource{}
+}
+
+type ServerResource struct {
+	config clients.Config
+}
+
+type ServerResourceModel struct {
+	ID               types.String   `tfsdk:"id"`
+	Name             types.String   `tfsdk:"name"`
+	Region           types.String   `tfsdk:"region"`
+	AvailabilityZone types.String   `tfsdk:"availability_zone"`
+	FlavorID         types.String   `tfsdk:"flavor_id"`
+	KeyPair          types.String   `tfsdk:"key_pair"`
+	UserData         types.String   `tfsdk:"user_data"`
+	OsID             types.String   `tfsdk:"os_id"`
+	RaidType         types.String   `tfsdk:"raid_type"`
+	Nics             []NicModel     `tfsdk:"nic"`
+	Bonds            []BondModel    `tfsdk:"bond"`
+	Timeouts         timeouts.Value `tfsdk:"timeouts"`
+}
+
+type NicModel struct {
+	Name  types.String `tfsdk:"name"`
+	Vlans []VlanModel  `tfsdk:"vlan"`
+}
+
+type BondModel struct {
+	Name           types.String `tfsdk:"name"`
+	InterfaceNames types.List   `tfsdk:"interface_names"`
+	Vlans          []VlanModel  `tfsdk:"vlan"`
+}
+
+type VlanModel struct {
+	ID        types.Int64  `tfsdk:"id"`
+	Native    types.Bool   `tfsdk:"native"`
+	NetworkId types.String `tfsdk:"network_id"`
+	SubnetId  types.String `tfsdk:"subnet_id"`
+}
+
+func (r *ServerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "vkcs_baremetal_server"
+}
+
+func (r *ServerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "ID of the bare metal server.",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the bare metal server.",
+			},
+			"region": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The region to fetch the bare metal server from, defaults to the provider's region.",
+			},
+			"availability_zone": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: "Availability zone. If not specified, we will chose the availability zone for you.",
+			},
+			"flavor_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Server flavor to rent.",
+			},
+			"key_pair": schema.StringAttribute{
+				Required:    true,
+				Description: "The name of a key pair to put on the server. The key pair must already be created and associated with the tenant's account. Changing this creates a new server.",
+			},
+			"user_data": schema.StringAttribute{
+				Optional:    true,
+				Description: "Provide the cloud-init user-data payload.",
+			},
+			"os_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "Set os id.",
+			},
+			"raid_type": schema.StringAttribute{
+				Optional:    true,
+				Description: "Parameter to determine should RAID be used during image flashing.",
+			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+				Read:   true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+		Blocks: map[string]schema.Block{
+			"nic": schema.ListNestedBlock{
+				Description: "Physical network interfaces.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required:    true,
+							Description: "Interface name (e.g. nic0, eno1). Acts as unique identifier.",
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"vlan": schema.ListNestedBlock{
+							Description:  "VLAN configuration. Allowed only if interface is not part of a bond.",
+							NestedObject: vlanObject(),
+						},
+					},
+				},
+			},
+			"bond": schema.ListNestedBlock{
+				Description: "Link aggregation interfaces (bonds).",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required:    true,
+							Description: "Bond interface name (e.g. bond0).",
+						},
+						"interface_names": schema.ListAttribute{
+							Required:    true,
+							Description: "List of interface names participating in the bond.",
+							ElementType: types.StringType,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"vlan": schema.ListNestedBlock{
+							Description:  "VLAN configuration applied to the bond.",
+							NestedObject: vlanObject(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func vlanObject() schema.NestedBlockObject {
+	return schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of the VLAN.",
+			},
+			"native": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Whether the VLAN is native.",
+			},
+			"network_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the network.",
+			},
+			"subnet_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the subnet.",
+			},
+		},
+	}
+}
+
+func (r *ServerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.config = req.ProviderData.(clients.Config)
+}
+
+func (r *ServerResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.AtLeastOneOf(
+			path.MatchRoot("nic"),
+			path.MatchRoot("bond"),
+		),
+	}
+}
+
+func (r *ServerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	reprovisionState, err := json.Marshal(reprovision{Enabled: true})
+	if err != nil {
+		resp.Diagnostics.AddError("Error encoding reprovision state", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, reprovisionKey, reprovisionState)...)
+
+	var plan ServerResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := plan.Region.ValueString()
+	if plan.Region.IsUnknown() {
+		region = r.config.GetRegion()
+		plan.Region = types.StringValue(region)
+		resp.Plan.SetAttribute(ctx, path.Root("region"), region)
+	}
+
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	var state ServerResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.Region.ValueString() != region {
+		return
+	}
+
+	if !plan.FlavorID.Equal(state.FlavorID) {
+		resp.Diagnostics.AddError(
+			"Field cannot be updated",
+			"flavor_id cannot be changed after creation",
+		)
+	}
+
+	if !plan.AvailabilityZone.Equal(state.AvailabilityZone) {
+		resp.Diagnostics.AddError(
+			"Field cannot be updated",
+			"availability_zone cannot be changed after creation",
+		)
+	}
+}
+
+func (r *ServerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data ServerResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := data.Region.ValueString()
+	if region == "" {
+		region = r.config.GetRegion()
+	}
+
+	ctx = tflog.SetField(ctx, "region", region)
+	client, err := r.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	serverID, d := rent(ctx, data, client)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.ID = types.StringValue(serverID)
+
+	updateOpts := servers.UpdateOpts{
+		ServerName: data.Name.ValueString(),
+	}
+
+	if err := servers.Update(client, data.ID.ValueString(), &updateOpts).ExtractErr(); err != nil {
+		resp.Diagnostics.AddError("Error renaming server", err.Error())
+		return
+	}
+
+	data.Region = types.StringValue(region)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ServerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ServerResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := state.Region.ValueString()
+	if region == "" {
+		region = r.config.GetRegion()
+	}
+
+	client, err := r.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	serverID := state.ID.ValueString()
+	if serverID == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	ctx = tflog.SetField(ctx, "server_id", serverID)
+
+	tflog.Debug(ctx, "Calling VKCS baremetal API to retrieve server by id", map[string]interface{}{"id": serverID})
+	server, err := servers.Get(client, serverID).Extract()
+	if errutil.IsNotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading baremetal server", err.Error())
+		return
+	}
+
+	state.Name = types.StringValue(server.ServerName)
+	state.Region = types.StringValue(region)
+	state.AvailabilityZone = types.StringValue(server.AvailabilityZone)
+	state.FlavorID = types.StringPointerValue(server.FlavorId)
+	state.RaidType = types.StringPointerValue(server.RaidType)
+	state.OsID = types.StringPointerValue(server.ImageId)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *ServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ServerResourceModel
+	var state ServerResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := state.Region.ValueString()
+	if region == "" {
+		region = r.config.GetRegion()
+	}
+
+	client, err := r.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	serverID := state.ID.ValueString()
+	plan.ID = state.ID
+
+	act := action(plan, state)
+	if act != nil {
+		resp.Diagnostics.Append(act(ctx, plan, client)...)
+	}
+
+	updateOpts := servers.UpdateOpts{
+		ServerName: plan.Name.ValueString(),
+	}
+
+	tflog.Debug(ctx, "Calling VKCS baremetal API to update server by id", map[string]interface{}{"id": serverID})
+	if err := servers.Update(client, serverID, &updateOpts).ExtractErr(); err != nil {
+		resp.Diagnostics.AddError("Error updating baremetal server", err.Error())
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *ServerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	val, diags := req.Private.GetKey(ctx, reprovisionKey)
+	resp.Diagnostics.Append(diags...)
+	if val != nil {
+		var reprovisionState reprovision
+		if err := json.Unmarshal(val, &reprovisionState); err != nil {
+			resp.Diagnostics.AddError("Error encoding reprovision state", err.Error())
+			return
+		}
+
+		if reprovisionState.Enabled {
+			tflog.Info(ctx, "Server will be reprovisioned")
+			return
+		}
+	}
+
+	var state ServerResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region := state.Region.ValueString()
+	if region == "" {
+		region = r.config.GetRegion()
+	}
+
+	client, err := r.config.BareMetalV1Client(region)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating VKCS baremetal API client", err.Error())
+		return
+	}
+
+	serverID := state.ID.ValueString()
+	if serverID == "" {
+		return
+	}
+
+	ctx = tflog.SetField(ctx, "server_id", serverID)
+	tflog.Debug(ctx, "Calling VKCS baremetal API to delete server by id", map[string]interface{}{"id": serverID})
+	if err := servers.Delete(client, serverID).ExtractErr(); err != nil && !errutil.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error deleting baremetal server", err.Error())
+		return
+	}
+}
+
+func (r *ServerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func rent(ctx context.Context, data ServerResourceModel, client *gophercloud.ServiceClient) (serverID string, diags diag.Diagnostics) {
+	timeout, d := data.Timeouts.Create(ctx, serverCreateTimeout)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+
+	createOpts := rents.CreateOpts{
+		ProvisionFields:  defineProvisionFields(ctx, data),
+		FlavorId:         data.FlavorID.ValueString(),
+		ServerCount:      1,
+		AvailabilityZone: data.AvailabilityZone.ValueStringPointer(),
+	}
+
+	tflog.Debug(ctx, "Calling VKCS baremetal API to create rent request")
+	rentReq, err := rents.Create(client, &createOpts).Extract()
+	if err != nil {
+		diags.AddError("Error creating baremetal server", err.Error())
+		return
+	}
+
+	if len(rentReq.ServerIds) != 1 {
+		diags.AddError("Error retrieving baremetal servers ID from list", fmt.Sprintf("%+v", rentReq.ServerIds))
+		return
+	}
+
+	serverID = rentReq.ServerIds[0]
+	tflog.SetField(ctx, "rent_request_id", rentReq.RentRequestId)
+
+	serverStateConf := &retry.StateChangeConf{
+		Pending:    []string{string(servers.StatusDiscovered), string(servers.StatusInProgress)},
+		Target:     []string{string(servers.StatusActive)},
+		Refresh:    provisionRefreshFunc(ctx, client, serverID),
+		Timeout:    timeout,
+		Delay:      serverDelay,
+		MinTimeout: serverMinTimeout,
+	}
+
+	if _, err := serverStateConf.WaitForStateContext(ctx); err != nil {
+		diags.AddError("Error waiting baremetal server", err.Error())
+		return
+	}
+
+	tflog.Debug(ctx, "Renting baremetal done")
+	return
+}
+
+func action(plan, state ServerResourceModel) func(context.Context, ServerResourceModel, *gophercloud.ServiceClient) diag.Diagnostics {
+	if needProvision(plan, state) {
+		return provision
+	}
+	if needUpdateNetworkConfig(plan, state) {
+		return updateNetworkConfig
+	}
+
+	return nil
+}
+
+func needProvision(plan, state ServerResourceModel) bool {
+	return !plan.OsID.Equal(state.OsID) ||
+		!plan.RaidType.Equal(state.RaidType) ||
+		!plan.UserData.Equal(state.UserData) ||
+		!plan.KeyPair.Equal(state.KeyPair)
+}
+
+func needUpdateNetworkConfig(plan, state ServerResourceModel) bool {
+	return !equalNICs(plan.Nics, state.Nics) || !equalBonds(plan.Bonds, state.Bonds)
+}
+
+func provision(ctx context.Context, data ServerResourceModel, client *gophercloud.ServiceClient) (diags diag.Diagnostics) {
+	timeout, d := data.Timeouts.Create(ctx, serverCreateTimeout)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+
+	provisionOpts := servers.ProvisionOpts{
+		ProvisionFields: defineProvisionFields(ctx, data),
+	}
+
+	serverID := data.ID.ValueString()
+
+	tflog.Debug(ctx, "Calling VKCS baremetal API to provisioning server by id", map[string]interface{}{"id": serverID})
+	if err := servers.Provision(client, serverID, &provisionOpts).ExtractErr(); err != nil {
+		diags.AddError("Error provisioning baremetal server", err.Error())
+		return
+	}
+
+	serverStateConf := &retry.StateChangeConf{
+		Pending:    []string{string(servers.StatusDiscovered), string(servers.StatusInProgress)},
+		Target:     []string{string(servers.StatusActive)},
+		Refresh:    provisionRefreshFunc(ctx, client, serverID),
+		Timeout:    timeout,
+		Delay:      serverDelay,
+		MinTimeout: serverMinTimeout,
+	}
+
+	if _, err := serverStateConf.WaitForStateContext(ctx); err != nil {
+		diags.AddError("Error waiting baremetal server", err.Error())
+		return
+	}
+
+	tflog.Debug(ctx, "Provisioning baremetal done")
+	return
+}
+
+func provisionRefreshFunc(ctx context.Context, client *gophercloud.ServiceClient, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		tflog.Debug(ctx, "Calling VKCS baremetal API to retrieve server by id", map[string]interface{}{"id": id})
+		server, err := servers.Get(client, id).Extract()
+		if err != nil {
+			return nil, "", err
+		}
+
+		return server, string(server.Status), nil
+	}
+}
+
+func updateNetworkConfig(ctx context.Context, data ServerResourceModel, client *gophercloud.ServiceClient) (diags diag.Diagnostics) {
+	timeout, d := data.Timeouts.Create(ctx, serverCreateTimeout)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+
+	updateNetworkConfigOpts := servers.UpdateNetworkConfigOpts{
+		NetworkInterfaces: flattenNetworkInterfaces(data.Nics),
+		Bonds:             flattenBonds(ctx, data.Bonds),
+	}
+
+	serverID := data.ID.ValueString()
+
+	tflog.Debug(ctx, "Calling VKCS baremetal API to updating network config by server id", map[string]interface{}{"id": serverID})
+	if err := servers.UpdateNetworkConfig(client, serverID, &updateNetworkConfigOpts).ExtractErr(); err != nil {
+		diags.AddError("Error update network config for baremetal server", err.Error())
+		return
+	}
+
+	serverStateConf := &retry.StateChangeConf{
+		Pending:    []string{string(servers.StatusInProgress)},
+		Target:     []string{string(servers.StatusActive)},
+		Refresh:    provisionRefreshFunc(ctx, client, serverID),
+		Timeout:    timeout,
+		Delay:      serverDelay,
+		MinTimeout: serverMinTimeout,
+	}
+
+	if _, err := serverStateConf.WaitForStateContext(ctx); err != nil {
+		diags.AddError("Error waiting baremetal server", err.Error())
+		return
+	}
+
+	tflog.Debug(ctx, "Updating network config done")
+	return
+}
+
+func defineProvisionFields(ctx context.Context, data ServerResourceModel) v1.ProvisionFields {
+	fields := v1.ProvisionFields{
+		ProvisionType:     v1.ProvisionTypeNOOS,
+		RaidType:          data.RaidType.ValueStringPointer(),
+		KeypairName:       data.KeyPair.ValueString(),
+		UserData:          encodeUserData(data.UserData), // base64 encode
+		NetworkInterfaces: flattenNetworkInterfaces(data.Nics),
+		Bonds:             flattenBonds(ctx, data.Bonds),
+	}
+
+	if !data.OsID.IsNull() && !data.OsID.IsUnknown() {
+		fields.ProvisionType = v1.ProvisionTypeIMAGE
+		fields.ImageSource = v1.ImageSourcePUBLIC
+		fields.ImageId = data.OsID.ValueStringPointer()
+	}
+
+	return fields
+}
+
+func flattenNetworkInterfaces(items []NicModel) []*v1.NetworkInterfaceConfig {
+	configs := make([]*v1.NetworkInterfaceConfig, 0, len(items))
+
+	for _, item := range items {
+		configs = append(configs, &v1.NetworkInterfaceConfig{
+			NicName: item.Name.ValueString(),
+			Vlans:   flattenVlans(item.Vlans),
+		})
+	}
+
+	sort.SliceStable(configs, func(i, j int) bool {
+		return configs[i].NicName < configs[j].NicName
+	})
+
+	return configs
+}
+
+func flattenVlans(items []VlanModel) []*v1.VlanConfig {
+	vlans := make([]*v1.VlanConfig, 0, len(items))
+
+	for _, vlan := range items {
+		vlans = append(vlans, &v1.VlanConfig{
+			VlanId:    vlan.ID.ValueInt64Pointer(),
+			IsNative:  vlan.Native.ValueBool(),
+			NetworkId: vlan.NetworkId.ValueString(),
+			SubnetId:  vlan.SubnetId.ValueString(),
+		})
+	}
+
+	sort.SliceStable(vlans, func(i, j int) bool {
+		vi, vj := int64(0), int64(0)
+
+		if vlans[i].VlanId != nil {
+			vi = *vlans[i].VlanId
+		}
+		if vlans[j].VlanId != nil {
+			vj = *vlans[j].VlanId
+		}
+		return vi < vj
+	})
+
+	return vlans
+}
+
+func flattenBonds(ctx context.Context, items []BondModel) []*v1.BondConfig {
+	bonds := make([]*v1.BondConfig, 0, len(items))
+	for _, item := range items {
+		var ifNames []string
+		item.InterfaceNames.ElementsAs(ctx, &ifNames, false)
+
+		bonds = append(bonds, &v1.BondConfig{
+			BondName:       item.Name.ValueString(),
+			InterfaceNames: ifNames,
+			Vlans:          flattenVlans(item.Vlans),
+		})
+	}
+
+	sort.SliceStable(bonds, func(i, j int) bool {
+		return bonds[i].BondName < bonds[j].BondName
+	})
+
+	return bonds
+}
+
+func encodeUserData(data types.String) *string {
+	if data.IsNull() {
+		return nil
+	}
+	value := base64.URLEncoding.EncodeToString([]byte(data.ValueString()))
+
+	return &value
+}
+
+func equalNICs(a, b []NicModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	a = slices.Clone(a)
+	b = slices.Clone(b)
+
+	slices.SortFunc(a, func(a, b NicModel) int {
+		return cmp.Compare(
+			a.Name.ValueString(),
+			b.Name.ValueString(),
+		)
+	})
+
+	slices.SortFunc(b, func(a, b NicModel) int {
+		return cmp.Compare(
+			a.Name.ValueString(),
+			b.Name.ValueString(),
+		)
+	})
+
+	return slices.EqualFunc(a, b, func(a, b NicModel) bool {
+		return a.Name.ValueString() == b.Name.ValueString() &&
+			equalVlans(a.Vlans, b.Vlans)
+	})
+}
+
+func equalBonds(a, b []BondModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	a = slices.Clone(a)
+	b = slices.Clone(b)
+
+	slices.SortFunc(a, func(a, b BondModel) int {
+		return cmp.Compare(
+			a.Name.ValueString(),
+			b.Name.ValueString(),
+		)
+	})
+
+	slices.SortFunc(b, func(a, b BondModel) int {
+		return cmp.Compare(
+			a.Name.ValueString(),
+			b.Name.ValueString(),
+		)
+	})
+
+	return slices.EqualFunc(a, b, func(a, b BondModel) bool {
+		return a.Name.ValueString() == b.Name.ValueString() &&
+			equalStringLists(a.InterfaceNames, b.InterfaceNames) &&
+			equalVlans(a.Vlans, b.Vlans)
+	})
+}
+
+func equalVlans(a, b []VlanModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	a = slices.Clone(a)
+	b = slices.Clone(b)
+
+	slices.SortFunc(a, func(a, b VlanModel) int {
+		return cmp.Compare(
+			a.ID.ValueInt64(),
+			b.ID.ValueInt64(),
+		)
+	})
+
+	slices.SortFunc(b, func(a, b VlanModel) int {
+		return cmp.Compare(
+			a.ID.ValueInt64(),
+			b.ID.ValueInt64(),
+		)
+	})
+
+	return slices.EqualFunc(a, b, func(a, b VlanModel) bool {
+		return a.ID.ValueInt64() == b.ID.ValueInt64() &&
+			a.Native.ValueBool() == b.Native.ValueBool() &&
+			a.NetworkId.ValueString() == b.NetworkId.ValueString() &&
+			a.SubnetId.ValueString() == b.SubnetId.ValueString()
+	})
+}
+
+func equalStringLists(a, b types.List) bool {
+	var aValues []string
+	var bValues []string
+
+	a.ElementsAs(context.Background(), &aValues, false)
+	b.ElementsAs(context.Background(), &bValues, false)
+
+	slices.Sort(aValues)
+	slices.Sort(bValues)
+
+	return slices.Equal(aValues, bValues)
+}

--- a/vkcs/baremetal/resource_server_test.go
+++ b/vkcs/baremetal/resource_server_test.go
@@ -1,0 +1,68 @@
+package baremetal_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/acctest"
+)
+
+// TestManualAccBareMetalServerResource_basic is a manual acceptance test.
+// It cannot be executed in an automated environment because provisioning
+// a vkcs_baremetal_server requires allocation of a real physical server,
+// which is costly, and not suitable for routine test runs. This is too inefficient.
+func TestManualAccBareMetalServerResource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.AccTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.AccTestRenderConfig(testAccServerResourceBasic, map[string]string{
+					"TestAccBaremetalOSDataSourceBasic":     acctest.AccTestRenderConfig(testAccOSDataSourceBasic),
+					"TestAccBaremetalFlavorDataSourceBasic": acctest.AccTestRenderConfig(testAccFlavorDataSourceBasic),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vkcs_baremetal_server.basic", "id"),
+					resource.TestCheckResourceAttr("vkcs_baremetal_server.basic", "name", "TerraformAccTestBasic"),
+					resource.TestCheckResourceAttr("vkcs_baremetal_server.basic", "availability_zone", "ME1"),
+				),
+			},
+		},
+	})
+}
+
+const testAccServerResourceBasic = `
+{{.TestAccBaremetalOSDataSourceBasic}}
+{{.TestAccBaremetalFlavorDataSourceBasic}}
+
+resource "vkcs_compute_keypair" "baremetal" {
+  name = "tf-baremetal-test-key-pair"
+}
+
+resource "vkcs_networking_network" "network" {
+  name        = "tf-baremetal-test-network"
+  description = "my network description"
+}
+
+resource "vkcs_networking_subnet" "subnet" {
+  name       = "tf-baremetal-test-subnet"
+  network_id = vkcs_networking_network.network.id
+}
+
+resource "vkcs_baremetal_server" "basic" {
+  name              = "TerraformAccTestBasic"
+  os_id             = data.vkcs_baremetal_os.basic.id
+  flavor_id         = data.vkcs_baremetal_flavor.basic.id
+  key_pair          = vkcs_compute_keypair.baremetal.name
+  availability_zone = "ME1"
+
+  nic {
+    name = "nic0"
+    vlan {
+      native     = true
+      network_id = vkcs_networking_network.network.id
+      subnet_id  = vkcs_networking_subnet.subnet.id
+    }
+  }
+}
+`

--- a/vkcs/internal/clients/client.go
+++ b/vkcs/internal/clients/client.go
@@ -34,6 +34,10 @@ func newBackupV1(client *gophercloud.ProviderClient, opts clientOpts) (*gophercl
 	return initClientOptsNew(client, opts, "data-protect")
 }
 
+func newBareMetalV1(client *gophercloud.ProviderClient, opts clientOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOptsNew(client, opts, "baremetal")
+}
+
 func newBlockStorageV3(client *gophercloud.ProviderClient, opts clientOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOptsNew(client, opts, "volumev3")
 }

--- a/vkcs/internal/clients/config.go
+++ b/vkcs/internal/clients/config.go
@@ -31,6 +31,7 @@ type Config interface {
 	GetMutex() *mutexkv.MutexKV
 
 	BackupV1Client(region string, tenantID string) (*gophercloud.ServiceClient, error)
+	BareMetalV1Client(region string) (*gophercloud.ServiceClient, error)
 	BlockStorageV3Client(region string) (*gophercloud.ServiceClient, error)
 	CDNV1Client(region string) (*gophercloud.ServiceClient, error)
 	ComputeV2Client(region string) (*gophercloud.ServiceClient, error)
@@ -80,6 +81,10 @@ func (c *config) BackupV1Client(region string, projectID string) (*gophercloud.S
 	client, err := c.initClient(newBackupV1, region, "backup")
 	client.Endpoint = fmt.Sprintf("%s%s/", client.Endpoint, projectID)
 	return client, err
+}
+
+func (c *config) BareMetalV1Client(region string) (*gophercloud.ServiceClient, error) {
+	return c.initClient(newBareMetalV1, region, "baremetal")
 }
 
 func (c *config) BlockStorageV3Client(region string) (*gophercloud.ServiceClient, error) {

--- a/vkcs/internal/services/baremetal/v1/flavors/requests.go
+++ b/vkcs/internal/services/baremetal/v1/flavors/requests.go
@@ -1,0 +1,62 @@
+package flavors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/errutil"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+type ListOpts struct {
+	CpuModel    *string `q:"cpuModel"`
+	CpuCoresMin *int64  `q:"cpuCoresMin"`
+	CpuCoresMax *int64  `q:"cpuCoresMax"`
+	RamSizeMin  *int64  `q:"ramSizeMin"`
+	RamSizeMax  *int64  `q:"ramSizeMax"`
+	SsdSizeMin  *int64  `q:"ssdSizeMin"`
+	SsdSizeMax  *int64  `q:"ssdSizeMax"`
+	HddSizeMin  *int64  `q:"hddSizeMin"`
+	HddSizeMax  *int64  `q:"hddSizeMax"`
+}
+
+// ToListQuery builds request params.
+func (opts *ListOpts) ToListQuery() (string, error) {
+	u, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+
+	return u.String(), err
+}
+
+// Get retrieves a baremetal flavor by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(flavorURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// List returns a pager to iterate over all baremetal flavors.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := flavorsURL(client)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return Page{
+			TokenPageBase: paginationutil.TokenPageBase{PageResult: r},
+		}
+	})
+}

--- a/vkcs/internal/services/baremetal/v1/flavors/requests.go
+++ b/vkcs/internal/services/baremetal/v1/flavors/requests.go
@@ -23,6 +23,10 @@ type ListOpts struct {
 	HddSizeMax  *int64  `q:"hddSizeMax"`
 }
 
+type UpdateOpts struct {
+	DisplayName *string `json:"displayName,omitempty"`
+}
+
 // ToListQuery builds request params.
 func (opts *ListOpts) ToListQuery() (string, error) {
 	u, err := gophercloud.BuildQueryString(opts)
@@ -37,6 +41,16 @@ func (opts *ListOpts) ToListQuery() (string, error) {
 func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
 	resp, err := client.Get(flavorURL(client, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// Update updates a baremetal flavor's project-specific display name by ID.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	resp, err := client.Put(flavorURL(client, id), opts, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))

--- a/vkcs/internal/services/baremetal/v1/flavors/results.go
+++ b/vkcs/internal/services/baremetal/v1/flavors/results.go
@@ -1,0 +1,65 @@
+package flavors
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+type DiskType string
+
+const (
+	DiskTypeSSD DiskType = "SSD"
+	DiskTypeHDD DiskType = "HDD"
+)
+
+type Disk struct {
+	Size int64    `json:"size"`
+	Type DiskType `json:"type"`
+}
+
+type NetworkInterface struct {
+	Name string `json:"name"`
+}
+
+type Flavor struct {
+	FlavorId           string              `json:"flavorId"`
+	FlavorName         string              `json:"flavorName"`
+	Status             string              `json:"status"`
+	CpuModel           string              `json:"cpuModel"`
+	CpuCores           int64               `json:"cpuCores"`
+	RamGb              int64               `json:"ramGb"`
+	Disks              []*Disk             `json:"disks"`
+	NetworkInterfaces  []*NetworkInterface `json:"networkInterfaces"`
+	ServersCountByAZ   map[string]*int64   `json:"serversCountByAZ"`
+	ServersCount       int64               `json:"serversCount"`
+	BondAndVlanCapable bool                `json:"bondAndVlanCapable"`
+}
+
+type commonFlavorResult struct {
+	gophercloud.Result
+}
+
+func (r commonFlavorResult) Extract() (*Flavor, error) {
+	var f Flavor
+	err := r.ExtractInto(&f)
+	return &f, err
+}
+
+// GetResult represents result of baremetal flavor get.
+type GetResult struct {
+	commonFlavorResult
+}
+
+// Page represents a page of baremetal flavors.
+type Page struct {
+	paginationutil.TokenPageBase
+}
+
+func ExtractFlavors(p pagination.Page) ([]Flavor, error) {
+	var s struct {
+		Items []Flavor `json:"items"`
+	}
+	err := p.(Page).ExtractInto(&s)
+	return s.Items, err
+}

--- a/vkcs/internal/services/baremetal/v1/flavors/results.go
+++ b/vkcs/internal/services/baremetal/v1/flavors/results.go
@@ -25,6 +25,7 @@ type NetworkInterface struct {
 type Flavor struct {
 	FlavorId           string              `json:"flavorId"`
 	FlavorName         string              `json:"flavorName"`
+	DisplayName        *string             `json:"displayName"`
 	Status             string              `json:"status"`
 	CpuModel           string              `json:"cpuModel"`
 	CpuCores           int64               `json:"cpuCores"`
@@ -49,6 +50,11 @@ func (r commonFlavorResult) Extract() (*Flavor, error) {
 // GetResult represents result of baremetal flavor get.
 type GetResult struct {
 	commonFlavorResult
+}
+
+// UpdateResult represents result of baremetal flavor update.
+type UpdateResult struct {
+	gophercloud.ErrResult
 }
 
 // Page represents a page of baremetal flavors.

--- a/vkcs/internal/services/baremetal/v1/flavors/urls.go
+++ b/vkcs/internal/services/baremetal/v1/flavors/urls.go
@@ -1,0 +1,15 @@
+package flavors
+
+import "github.com/gophercloud/gophercloud"
+
+func baseURL() string {
+	return "flavors"
+}
+
+func flavorsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(baseURL())
+}
+
+func flavorURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(baseURL(), id)
+}

--- a/vkcs/internal/services/baremetal/v1/images/requests.go
+++ b/vkcs/internal/services/baremetal/v1/images/requests.go
@@ -1,0 +1,28 @@
+package images
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/errutil"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+// Get retrieves a baremetal image by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(imageURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// List returns a pager to iterate over all baremetal images.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	url := imagesURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return Page{
+			TokenPageBase: paginationutil.TokenPageBase{PageResult: r},
+		}
+	})
+}

--- a/vkcs/internal/services/baremetal/v1/images/results.go
+++ b/vkcs/internal/services/baremetal/v1/images/results.go
@@ -1,0 +1,47 @@
+package images
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+type Image struct {
+	ImageId              string `json:"imageId"`
+	ImageName            string `json:"imageName"`
+	OsType               string `json:"osType"`
+	OsVersion            string `json:"osVersion"`
+	DiskFormat           string `json:"diskFormat"`
+	MinDiskGb            int64  `json:"minDiskGb"`
+	Username             string `json:"username"`
+	OsLocalizationStatus string `json:"osLocalizationStatus"`
+	RaidType             string `json:"raidType"`
+}
+
+type commonFlavorResult struct {
+	gophercloud.Result
+}
+
+func (r commonFlavorResult) Extract() (*Image, error) {
+	var i Image
+	err := r.ExtractInto(&i)
+	return &i, err
+}
+
+// GetResult represents result of baremetal image get.
+type GetResult struct {
+	commonFlavorResult
+}
+
+// Page represents a page of baremetal images.
+type Page struct {
+	paginationutil.TokenPageBase
+}
+
+func ExtractImages(p pagination.Page) ([]Image, error) {
+	var s struct {
+		Items []Image `json:"items"`
+	}
+	err := p.(Page).ExtractInto(&s)
+	return s.Items, err
+}

--- a/vkcs/internal/services/baremetal/v1/images/urls.go
+++ b/vkcs/internal/services/baremetal/v1/images/urls.go
@@ -1,0 +1,15 @@
+package images
+
+import "github.com/gophercloud/gophercloud"
+
+func baseURL() string {
+	return "images"
+}
+
+func imagesURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(baseURL())
+}
+
+func imageURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(baseURL(), id)
+}

--- a/vkcs/internal/services/baremetal/v1/rents/requests.go
+++ b/vkcs/internal/services/baremetal/v1/rents/requests.go
@@ -1,0 +1,62 @@
+package rents
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	v1 "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/errutil"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+type OptsBuilder interface {
+	Map() (map[string]interface{}, error)
+}
+
+type CreateOpts struct {
+	v1.ProvisionFields
+	FlavorId         string   `json:"flavorId"`
+	ServerCount      int64    `json:"serverCount"`
+	AvailabilityZone *string  `json:"availabilityZone"`
+	Tags             []string `json:"tags"`
+}
+
+// Map builds the request body.
+func (opts *CreateOpts) Map() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create sends a request to create a baremetal rent request.
+func Create(client *gophercloud.ServiceClient, opts OptsBuilder) (r CreateResult) {
+	b, err := opts.Map()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(rentRequestsURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// Get retrieves a baremetal rent request by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(rentRequestURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// List returns a pager to iterate over all baremetal rent requests.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	url := rentRequestsURL(client)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return Page{
+			TokenPageBase: paginationutil.TokenPageBase{PageResult: r},
+		}
+	})
+}

--- a/vkcs/internal/services/baremetal/v1/rents/results.go
+++ b/vkcs/internal/services/baremetal/v1/rents/results.go
@@ -1,0 +1,45 @@
+package rents
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+type RentRequest struct {
+	RentRequestId string   `json:"rentRequestId"`
+	ServerIds     []string `json:"serverIds"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+func (r commonResult) Extract() (*RentRequest, error) {
+	var rent RentRequest
+	err := r.ExtractInto(&rent)
+	return &rent, err
+}
+
+// CreateResult represents result of baremetal rent request create.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents result of baremetal rent request get.
+type GetResult struct {
+	commonResult
+}
+
+// Page represents a page of baremetal rent request.
+type Page struct {
+	paginationutil.TokenPageBase
+}
+
+func ExtractRentRequests(p pagination.Page) ([]RentRequest, error) {
+	var s struct {
+		Items []RentRequest `json:"items"`
+	}
+	err := p.(Page).ExtractInto(&s)
+	return s.Items, err
+}

--- a/vkcs/internal/services/baremetal/v1/rents/urls.go
+++ b/vkcs/internal/services/baremetal/v1/rents/urls.go
@@ -1,0 +1,15 @@
+package rents
+
+import "github.com/gophercloud/gophercloud"
+
+func baseURL() string {
+	return "rent-requests"
+}
+
+func rentRequestsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(baseURL())
+}
+
+func rentRequestURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(baseURL(), id)
+}

--- a/vkcs/internal/services/baremetal/v1/servers/requests.go
+++ b/vkcs/internal/services/baremetal/v1/servers/requests.go
@@ -1,0 +1,116 @@
+package servers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	v1 "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/services/baremetal/v1"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/errutil"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+type OptsBuilder interface {
+	Map() (map[string]interface{}, error)
+}
+
+type UpdateOpts struct {
+	ServerName string `json:"serverName"`
+}
+
+// Map builds the request body.
+func (opts *UpdateOpts) Map() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+type ProvisionOpts struct {
+	v1.ProvisionFields
+}
+
+type UpdateNetworkConfigOpts struct {
+	NetworkInterfaces []*v1.NetworkInterfaceConfig `json:"networkInterfaces,omitempty"`
+	Bonds             []*v1.BondConfig             `json:"bonds,omitempty"`
+}
+
+func (opts *UpdateNetworkConfigOpts) Map() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Map builds the request body.
+func (opts *ProvisionOpts) Map() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Get retrieves a baremetal server by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(serverURL(client, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// Update updates a baremetal server by ID.
+func Update(client *gophercloud.ServiceClient, id string, opts OptsBuilder) (r UpdateResult) {
+	b, err := opts.Map()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Put(serverURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// Delete removes a baremetal server by ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(serverURL(client, id), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+// List returns a pager to iterate over all baremetal servers.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, serversURL(client), func(r pagination.PageResult) pagination.Page {
+		return Page{
+			TokenPageBase: paginationutil.TokenPageBase{PageResult: r},
+		}
+	})
+}
+
+// Provision starts provisioning of a baremetal server by ID.
+func Provision(client *gophercloud.ServiceClient, id string, opts OptsBuilder) (r ProvisionResult) {
+	b, err := opts.Map()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(provisionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}
+
+func UpdateNetworkConfig(client *gophercloud.ServiceClient, id string, opts OptsBuilder) (r UpdateNetworkConfigResult) {
+	b, err := opts.Map()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(updateNetworkConfigURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	r.Err = errutil.ErrorWithRequestID(r.Err, r.Header.Get(errutil.RequestIDHeader))
+	return
+}

--- a/vkcs/internal/services/baremetal/v1/servers/results.go
+++ b/vkcs/internal/services/baremetal/v1/servers/results.go
@@ -1,0 +1,98 @@
+package servers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	paginationutil "github.com/vk-cs/terraform-provider-vkcs/vkcs/internal/util/pagination"
+)
+
+type Status string
+
+const (
+	StatusDiscovered Status = "DISCOVERED"
+	StatusInProgress Status = "IN_PROGRESS"
+	StatusActive     Status = "ACTIVE"
+)
+
+type BootOrderListItem struct {
+	BootDeviceType string `json:"BootDeviceType"`
+}
+
+type LocalDiskInfo struct {
+	Path   string  `json:"path"`
+	SizeGb int64   `json:"sizeGb"`
+	Type   string  `json:"type"`
+	Model  *string `json:"model"`
+}
+
+type Server struct {
+	ServerId          string               `json:"serverId"`
+	ServerName        string               `json:"serverName"`
+	ImageId           *string              `json:"imageId"`
+	ImageSource       *string              `json:"imageSource"`
+	ImageName         *string              `json:"imageName"`
+	OsType            *string              `json:"osType"`
+	Status            Status               `json:"status"`
+	PowerState        string               `json:"powerState"`
+	CpuTypes          []string             `json:"cpuTypes"`
+	CpuCores          []int64              `json:"cpuCores"`
+	MemoryMegabytes   int64                `json:"memoryMegabytes"`
+	LocalDiskSizes    []int64              `json:"localDiskSizes"`
+	AvailabilityZone  string               `json:"availabilityZone"`
+	Tags              []string             `json:"tags"`
+	IsLocked          bool                 `json:"isLocked"`
+	TargetBootOrder   []*BootOrderListItem `json:"targetBootOrder"`
+	ImageUsername     *string              `json:"imageUsername"`
+	RaidType          *string              `json:"raidType"`
+	FlavorId          *string              `json:"flavorId"`
+	ProvisionProgress *int                 `json:"provisionProgress"`
+	LocalDisksInfo    []*LocalDiskInfo     `json:"localDisksInfo"`
+}
+
+type commonServerResult struct {
+	gophercloud.Result
+}
+
+func (r commonServerResult) Extract() (*Server, error) {
+	var s Server
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetResult represents result of baremetal server get
+type GetResult struct {
+	commonServerResult
+}
+
+type UpdateResult struct {
+	gophercloud.ErrResult
+}
+
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+type ProvisionResult struct {
+	gophercloud.ErrResult
+}
+
+type UpdateNetworkConfigResult struct {
+	gophercloud.ErrResult
+}
+
+// Page represents a page of baremetal server.
+type Page struct {
+	paginationutil.TokenPageBase
+}
+
+func (p Page) ExtractInto(v interface{}) error {
+	return p.PageResult.ExtractInto(v)
+}
+
+func ExtractServers(p pagination.Page) ([]Server, error) {
+	var s struct {
+		Items []Server `json:"items"`
+	}
+	err := p.(Page).ExtractInto(&s)
+	return s.Items, err
+}

--- a/vkcs/internal/services/baremetal/v1/servers/urls.go
+++ b/vkcs/internal/services/baremetal/v1/servers/urls.go
@@ -1,0 +1,23 @@
+package servers
+
+import "github.com/gophercloud/gophercloud"
+
+func baseURL() string {
+	return "servers"
+}
+
+func serversURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(baseURL())
+}
+
+func serverURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(baseURL(), id)
+}
+
+func provisionURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(baseURL(), id, "provision")
+}
+
+func updateNetworkConfigURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(baseURL(), id, "update-network-config")
+}

--- a/vkcs/internal/services/baremetal/v1/shared.go
+++ b/vkcs/internal/services/baremetal/v1/shared.go
@@ -1,0 +1,45 @@
+package v1
+
+type ProvisionType string
+
+const (
+	ProvisionTypeIMAGE ProvisionType = "IMAGE"
+	ProvisionTypeCDROM ProvisionType = "CDROM"
+	ProvisionTypeNOOS  ProvisionType = "NO_OS"
+)
+
+type ImageSource string
+
+const (
+	ImageSourceGLANCE ImageSource = "GLANCE"
+	ImageSourcePUBLIC ImageSource = "PUBLIC"
+)
+
+type ProvisionFields struct {
+	ProvisionType     ProvisionType             `json:"provisionType,omitempty"`
+	ImageId           *string                   `json:"imageId,omitempty"`
+	ImageSource       ImageSource               `json:"imageSource,omitempty"`
+	KeypairName       string                    `json:"keypairName,omitempty"`
+	UserData          *string                   `json:"userData,omitempty"`
+	NetworkInterfaces []*NetworkInterfaceConfig `json:"networkInterfaces,omitempty"`
+	Bonds             []*BondConfig             `json:"bonds,omitempty"`
+	RaidType          *string                   `json:"raidType,omitempty"`
+}
+
+type NetworkInterfaceConfig struct {
+	NicName string        `json:"nicName"`
+	Vlans   []*VlanConfig `json:"vlans"`
+}
+
+type BondConfig struct {
+	BondName       string        `json:"bondName"`
+	InterfaceNames []string      `json:"interfaceNames"`
+	Vlans          []*VlanConfig `json:"vlans"`
+}
+
+type VlanConfig struct {
+	VlanId    *int64 `json:"vlanId"`
+	IsNative  bool   `json:"isNative"`
+	NetworkId string `json:"networkId"`
+	SubnetId  string `json:"subnetId"`
+}

--- a/vkcs/internal/util/pagination/token.go
+++ b/vkcs/internal/util/pagination/token.go
@@ -1,0 +1,45 @@
+package pagination
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type TokenPageBase struct {
+	pagination.PageResult
+}
+
+type pageResponse struct {
+	Items     []any  `json:"items"`
+	NextToken string `json:"nextToken"`
+}
+
+func (current TokenPageBase) IsEmpty() (bool, error) {
+	var resp pageResponse
+	if err := current.ExtractInto(&resp); err != nil {
+		return false, err
+	}
+	return len(resp.Items) == 0, nil
+}
+
+func (current TokenPageBase) NextPageURL() (string, error) {
+	var resp pageResponse
+	if err := current.ExtractInto(&resp); err != nil {
+		return "", err
+	}
+
+	if resp.NextToken == "" {
+		return "", nil
+	}
+
+	curURL := current.URL
+	q := curURL.Query()
+
+	q.Set("nextToken", resp.NextToken)
+	curURL.RawQuery = q.Encode()
+
+	return curURL.String(), nil
+}
+
+func (current TokenPageBase) GetBody() any {
+	return current.Body
+}

--- a/vkcs/provider/provider.go
+++ b/vkcs/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/vk-cs/terraform-provider-vkcs/vkcs/backup"
+	"github.com/vk-cs/terraform-provider-vkcs/vkcs/baremetal"
 	"github.com/vk-cs/terraform-provider-vkcs/vkcs/cdn"
 	"github.com/vk-cs/terraform-provider-vkcs/vkcs/dataplatform"
 	"github.com/vk-cs/terraform-provider-vkcs/vkcs/db"
@@ -61,6 +62,7 @@ type vkcsProviderModel struct {
 
 type vkcsProviderEndpointOverridesModel struct {
 	Backup               types.String `tfsdk:"backup"`
+	BareMetal            types.String `tfsdk:"baremetal"`
 	BlockStorage         types.String `tfsdk:"block_storage"`
 	CDN                  types.String `tfsdk:"cdn"`
 	Compute              types.String `tfsdk:"compute"`
@@ -147,6 +149,10 @@ func (p *vkcsProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp 
 						"backup": schema.StringAttribute{
 							Optional:    true,
 							Description: "Backup API custom endpoint.",
+						},
+						"baremetal": schema.StringAttribute{
+							Optional:    true,
+							Description: "Bare Metal API custom endpoint.",
 						},
 						"block_storage": schema.StringAttribute{
 							Optional:    true,
@@ -252,6 +258,7 @@ func (p *vkcsProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 		endpointOverrides = map[string]any{
 			"backup":                 eo.Backup.ValueString(),
+			"baremetal":              eo.BareMetal.ValueString(),
 			"block-storage":          eo.BlockStorage.ValueString(),
 			"cdn":                    eo.CDN.ValueString(),
 			"compute":                eo.Compute.ValueString(),
@@ -306,6 +313,11 @@ func (p *vkcsProvider) DataSources(_ context.Context) []func() datasource.DataSo
 		backup.NewPlanDataSource,
 		backup.NewProviderDataSource,
 		backup.NewProvidersDataSource,
+		baremetal.NewFlavorDataSource,
+		baremetal.NewFlavorsDataSource,
+		baremetal.NewOSDataSource,
+		baremetal.NewOSesDataSource,
+		baremetal.NewServerDataSource,
 		cdn.NewOriginGroupDataSource,
 		cdn.NewShieldingPopDataSource,
 		cdn.NewShieldingPopsDataSource,
@@ -349,6 +361,7 @@ func (p *vkcsProvider) DataSources(_ context.Context) []func() datasource.DataSo
 func (p *vkcsProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		backup.NewPlanResource,
+		baremetal.NewServerResource,
 		cdn.NewOriginGroupResource,
 		cdn.NewResourceResource,
 		cdn.NewSslCertificateResource,

--- a/vkcs/provider/provider.go
+++ b/vkcs/provider/provider.go
@@ -361,6 +361,7 @@ func (p *vkcsProvider) DataSources(_ context.Context) []func() datasource.DataSo
 func (p *vkcsProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		backup.NewPlanResource,
+		baremetal.NewFlavorDisplayNameResource,
 		baremetal.NewServerResource,
 		cdn.NewOriginGroupResource,
 		cdn.NewResourceResource,

--- a/vkcs/provider/sdk_provider.go
+++ b/vkcs/provider/sdk_provider.go
@@ -103,6 +103,11 @@ func SDKProviderBase() *sdkschema.Provider {
 							Optional:    true,
 							Description: "Backup API custom endpoint.",
 						},
+						"baremetal": {
+							Type:        sdkschema.TypeString,
+							Optional:    true,
+							Description: "Bare Metal API custom endpoint.",
+						},
 						"block_storage": {
 							Type:        sdkschema.TypeString,
 							Optional:    true,
@@ -298,6 +303,7 @@ func SDKProviderBase() *sdkschema.Provider {
 
 			endpointOverrides = map[string]any{
 				"backup":                 m["backup"],
+				"baremetal":              m["baremetal"],
 				"block-storage":          m["block_storage"],
 				"cdn":                    m["cdn"],
 				"compute":                m["compute"],


### PR DESCRIPTION
### Summary

This pull request introduces initial support for the **Bare Metal** service in the VKCS Terraform provider.

### Details

* Added a new resource:

  * `vkcs_baremetal_server`

* Added new data sources:

  * `vkcs_baremetal_flavor`
  * `vkcs_baremetal_flavors`
  * `vkcs_baremetal_os`
  * `vkcs_baremetal_oses`
  * `vkcs_baremetal_server`

### Notes

* The Bare Metal service is currently in **beta testing** and is **not publicly available**.
* The implementation is intended for early validation and internal/testing use cases.

### Documentation

* Added documentation for the new resource and data sources.
* Included usage examples to demonstrate typical workflows.

### Additional Context

This change lays the groundwork for future expansion of Bare Metal support as the service matures and becomes publicly accessible.
