### PR TITLE
Do not read backup_schedule if it wasn't present in manifest for db resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ description: |-
 ---
 
 # VKCS Provider's changelog
+#### v0.17.3 (unreleased)
+- Fix backup_schedule causing update of db resources when it was not present in configuration.
+
 #### v0.17.2
 - Update default identity endpoint
 - Add guides for Kubernetes: kubernetes_cluster_v2_getting_started and kubernetes_cluster_v2_updating.

--- a/vkcs/db/resource_cluster.go
+++ b/vkcs/db/resource_cluster.go
@@ -733,18 +733,18 @@ func resourceDatabaseClusterRead(ctx context.Context, d *schema.ResourceData, me
 
 		d.Set("instances", flattenDatabaseClusterInstances(cluster.Instances))
 	}
-
-	backupSchedule, err := clusters.GetBackupSchedule(DatabaseV1Client, d.Id()).Extract()
-	if err != nil {
-		return diag.Errorf("error getting backup schedule for cluster: %s: %s", d.Id(), err)
+	if _, ok := d.GetOk("backup_schedule"); ok {
+		backupSchedule, err := clusters.GetBackupSchedule(DatabaseV1Client, d.Id()).Extract()
+		if err != nil {
+			return diag.Errorf("error getting backup schedule for cluster: %s: %s", d.Id(), err)
+		}
+		if backupSchedule != nil {
+			flattened := flattenDatabaseBackupSchedule(*backupSchedule)
+			d.Set("backup_schedule", flattened)
+		} else {
+			d.Set("backup_schedule", nil)
+		}
 	}
-	if backupSchedule != nil {
-		flattened := flattenDatabaseBackupSchedule(*backupSchedule)
-		d.Set("backup_schedule", flattened)
-	} else {
-		d.Set("backup_schedule", nil)
-	}
-
 	if !d.HasChangesExcept() {
 		return nil
 	}

--- a/vkcs/db/resource_instance.go
+++ b/vkcs/db/resource_instance.go
@@ -721,15 +721,17 @@ func resourceDatabaseInstanceRead(ctx context.Context, d *schema.ResourceData, m
 		d.Set("replica_of", instance.ReplicaOf.ID)
 	}
 
-	backupSchedule, err := instances.GetBackupSchedule(DatabaseV1Client, d.Id()).Extract()
-	if err != nil {
-		return diag.Errorf("error getting backup schedule for instance: %s: %s", d.Id(), err)
-	}
-	if backupSchedule != nil {
-		flattened := flattenDatabaseBackupSchedule(*backupSchedule)
-		d.Set("backup_schedule", flattened)
-	} else {
-		d.Set("backup_schedule", nil)
+	if _, ok := d.GetOk("backup_schedule"); ok {
+		backupSchedule, err := instances.GetBackupSchedule(DatabaseV1Client, d.Id()).Extract()
+		if err != nil {
+			return diag.Errorf("error getting backup schedule for instance: %s: %s", d.Id(), err)
+		}
+		if backupSchedule != nil {
+			flattened := flattenDatabaseBackupSchedule(*backupSchedule)
+			d.Set("backup_schedule", flattened)
+		} else {
+			d.Set("backup_schedule", nil)
+		}
 	}
 
 	d.Set("ip", instance.IP)


### PR DESCRIPTION
Default backend values cause terraform to detect drift; in future this field will be marked as required